### PR TITLE
fix: initialize animations with default values in init state

### DIFF
--- a/lib/src/components/layout/accordion.dart
+++ b/lib/src/components/layout/accordion.dart
@@ -176,6 +176,21 @@ class _AccordionItemState extends State<AccordionItem>
   void initState() {
     super.initState();
     _expanded.value = widget.expanded;
+    _updateAnimations();
+  }
+
+  void _updateAnimations() {
+    _controller?.dispose();
+    _controller = AnimationController(
+      vsync: this,
+      duration: _theme?.duration ?? const Duration(milliseconds: 200),
+      value: _expanded.value ? 1 : 0,
+    );
+    _easeInAnimation = CurvedAnimation(
+      parent: _controller!,
+      curve: _theme?.curve ?? Curves.easeIn,
+      reverseCurve: _theme?.reverseCurve ?? Curves.easeOut,
+    );
   }
 
   @override
@@ -193,17 +208,7 @@ class _AccordionItemState extends State<AccordionItem>
 
     if (_theme != theme) {
       _theme = theme;
-      _controller?.dispose();
-      _controller = AnimationController(
-        vsync: this,
-        duration: theme?.duration ?? const Duration(milliseconds: 200),
-        value: _expanded.value ? 1 : 0,
-      );
-      _easeInAnimation = CurvedAnimation(
-        parent: _controller!,
-        curve: theme?.curve ?? Curves.easeIn,
-        reverseCurve: theme?.reverseCurve ?? Curves.easeOut,
-      );
+      _updateAnimations();
     }
   }
 


### PR DESCRIPTION
This prevents an error where `_controller ` and `_easeInAnimation` are null if no `AccordionTheme` is provided.

<details>
<summary>The error in question</summary>

```
════════ Exception caught by widgets library ═══════════════════════════════════
The following _TypeError was thrown building AccordionItem(dirty, dependencies: [Theme, _InheritedData<_AccordionState>], state: _AccordionItemState#6c12a):
Null check operator used on a null value

The relevant error-causing widget was:
    AccordionItem AccordionItem:file:///home/archlinux/git/shadcn_flutter/docs/lib/pages/docs/introduction_page.dart:83:21
```

</details>

