### PR TITLE
Clickable Cards

### DIFF
--- a/lib/src/components/layout/card.dart
+++ b/lib/src/components/layout/card.dart
@@ -13,6 +13,7 @@ class Card extends StatelessWidget {
   final double? surfaceOpacity;
   final double? surfaceBlur;
   final Duration? duration;
+  final VoidCallback? onPressed;
 
   const Card({
     super.key,
@@ -28,12 +29,20 @@ class Card extends StatelessWidget {
     this.surfaceOpacity,
     this.surfaceBlur,
     this.duration,
+    this.onPressed,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    Widget m = DefaultTextStyle.merge(
+      child: child,
+      style: TextStyle(
+        color: theme.colorScheme.cardForeground,
+      ),
+    );
+    EdgeInsetsGeometry p = padding ?? (EdgeInsets.all(16 * scaling));
     return OutlinedContainer(
       clipBehavior: clipBehavior,
       borderRadius: borderRadius,
@@ -43,16 +52,19 @@ class Card extends StatelessWidget {
           ? fillColor ?? theme.colorScheme.border
           : theme.colorScheme.card,
       boxShadow: boxShadow,
-      padding: padding ?? (EdgeInsets.all(16 * scaling)),
+      padding: onPressed != null ? EdgeInsets.zero : p,
       surfaceOpacity: surfaceOpacity,
       surfaceBlur: surfaceBlur,
       duration: duration,
-      child: DefaultTextStyle.merge(
-        child: child,
-        style: TextStyle(
-          color: theme.colorScheme.cardForeground,
-        ),
-      ),
+      child: onPressed != null
+          ? GhostButton(
+              onPressed: onPressed,
+              density: ButtonDensity.compact,
+              child: Padding(
+                padding: p,
+                child: m,
+              ))
+          : m,
     );
   }
 }


### PR DESCRIPTION
Simply allows cards to be pressed with an onPressed VoidCallback. For compatibility it simply uses a GhostButton in the cards child. In the event that a card is clickable, it's padding is used in the ghost button and not the card, otherwise it functions as cards always have. 