### PR TITLE
Support enabled property on ContextMenu

### DIFF
--- a/lib/src/components/menu/context_menu.dart
+++ b/lib/src/components/menu/context_menu.dart
@@ -453,22 +453,22 @@ class _ContextMenuState extends State<ContextMenu> {
     final bool enableLongPress = platform == TargetPlatform.iOS ||
         platform == TargetPlatform.android ||
         platform == TargetPlatform.fuchsia;
-    return widget.enabled
-        ? GestureDetector(
-            behavior: widget.behavior,
-            onSecondaryTapDown: (details) {
+    return GestureDetector(
+      behavior: widget.behavior,
+      onSecondaryTapDown: !widget.enabled
+          ? null
+          : (details) {
               _showContextMenu(
                   context, details.globalPosition, _children, widget.direction);
             },
-            onLongPressStart: enableLongPress
-                ? (details) {
-                    _showContextMenu(context, details.globalPosition, _children,
-                        widget.direction);
-                  }
-                : null,
-            child: widget.child,
-          )
-        : widget.child;
+      onLongPressStart: enableLongPress && widget.enabled
+          ? (details) {
+              _showContextMenu(
+                  context, details.globalPosition, _children, widget.direction);
+            }
+          : null,
+      child: widget.child,
+    );
   }
 }
 

--- a/lib/src/components/menu/context_menu.dart
+++ b/lib/src/components/menu/context_menu.dart
@@ -408,14 +408,15 @@ class ContextMenu extends StatefulWidget {
   final List<MenuItem> items;
   final HitTestBehavior behavior;
   final Axis direction;
+  final bool enabled;
 
-  const ContextMenu({
-    super.key,
-    required this.child,
-    required this.items,
-    this.behavior = HitTestBehavior.translucent,
-    this.direction = Axis.vertical,
-  });
+  const ContextMenu(
+      {super.key,
+      required this.child,
+      required this.items,
+      this.behavior = HitTestBehavior.translucent,
+      this.direction = Axis.vertical,
+      this.enabled = true});
 
   @override
   State<ContextMenu> createState() => _ContextMenuState();
@@ -452,20 +453,22 @@ class _ContextMenuState extends State<ContextMenu> {
     final bool enableLongPress = platform == TargetPlatform.iOS ||
         platform == TargetPlatform.android ||
         platform == TargetPlatform.fuchsia;
-    return GestureDetector(
-      behavior: widget.behavior,
-      onSecondaryTapDown: (details) {
-        _showContextMenu(
-            context, details.globalPosition, _children, widget.direction);
-      },
-      onLongPressStart: enableLongPress
-          ? (details) {
+    return widget.enabled
+        ? GestureDetector(
+            behavior: widget.behavior,
+            onSecondaryTapDown: (details) {
               _showContextMenu(
                   context, details.globalPosition, _children, widget.direction);
-            }
-          : null,
-      child: widget.child,
-    );
+            },
+            onLongPressStart: enableLongPress
+                ? (details) {
+                    _showContextMenu(context, details.globalPosition, _children,
+                        widget.direction);
+                  }
+                : null,
+            child: widget.child,
+          )
+        : widget.child;
   }
 }
 


### PR DESCRIPTION
If its disabled it will just return the child. Obviously defaults to enabled = true

```dart
return widget.enabled
        ? GestureDetector(
            ...
            child: widget.child,
          )
        : widget.child;
```