### PR TITLE
Expose onEditingComplete event on NumberInput

### DIFF
--- a/lib/src/components/form/number_input.dart
+++ b/lib/src/components/form/number_input.dart
@@ -18,6 +18,7 @@ class NumberInput extends StatefulWidget {
   final AbstractButtonStyle? buttonStyle;
   final TextStyle? style;
   final EdgeInsetsGeometry? padding;
+  final VoidCallback? onEditingComplete;
 
   const NumberInput({
     super.key,
@@ -36,6 +37,7 @@ class NumberInput extends StatefulWidget {
     this.onChanged,
     this.buttonStyle,
     this.style,
+    this.onEditingComplete,
   });
 
   @override
@@ -302,6 +304,7 @@ class _NumberInputState extends State<NumberInput> {
           _lastValidValue = value;
           _controller.text = _valueAsString;
           widget.onChanged?.call(_lastValidValue);
+          widget.onEditingComplete?.call();
         },
         borderRadius: widget.showButtons
             ? BorderRadiusDirectional.only(


### PR DESCRIPTION
It simply calls onEditingComplete after the NumberInput has done it's onEditingComplete logic. I've been using this change and need it for a few forms I've built.