### PR TITLE
Revert Placeholder Text Widget Change

### DIFF
--- a/docs/lib/pages/docs/components/card/card_example_1.dart
+++ b/docs/lib/pages/docs/components/card/card_example_1.dart
@@ -16,11 +16,11 @@ class CardExample1 extends StatelessWidget {
           const SizedBox(height: 24),
           const Text('Name').semiBold().small(),
           const SizedBox(height: 4),
-          const TextField(placeholder: Text('Name of your project')),
+          const TextField(placeholder: 'Name of your project'),
           const SizedBox(height: 16),
           const Text('Description').semiBold().small(),
           const SizedBox(height: 4),
-          const TextField(placeholder: Text('Description of your project')),
+          const TextField(placeholder: 'Description of your project'),
           const SizedBox(height: 24),
           Row(
             children: [

--- a/docs/lib/pages/docs/components/input/input_example_1.dart
+++ b/docs/lib/pages/docs/components/input/input_example_1.dart
@@ -6,7 +6,7 @@ class InputExample1 extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const TextField(
-      placeholder: Text('Enter your name'),
+      placeholder: 'Enter your name',
     );
   }
 }

--- a/docs/lib/pages/docs/components/input/input_example_2.dart
+++ b/docs/lib/pages/docs/components/input/input_example_2.dart
@@ -7,7 +7,7 @@ class InputExample2 extends StatelessWidget {
   Widget build(BuildContext context) {
     return const TextField(
       initialValue: 'Hello World!',
-      placeholder: Text('Enter your message'),
+      placeholder: 'Enter your message',
     );
   }
 }

--- a/docs/lib/pages/docs/components/sheet/sheet_example_1.dart
+++ b/docs/lib/pages/docs/components/sheet/sheet_example_1.dart
@@ -69,7 +69,7 @@ class _SheetExample1State extends State<SheetExample1> {
                       const NotEmptyValidator() & const LengthValidator(min: 4),
                   child: const TextField(
                     initialValue: 'Thito Yalasatria Sunarya',
-                    placeholder: Text('Your fullname'),
+                    placeholder: 'Your fullname',
                   ),
                 ),
                 FormField<String>(
@@ -79,7 +79,7 @@ class _SheetExample1State extends State<SheetExample1> {
                       const NotEmptyValidator() & const LengthValidator(min: 4),
                   child: const TextField(
                     initialValue: '@sunarya-thito',
-                    placeholder: Text('Your username'),
+                    placeholder: 'Your username',
                   ),
                 ),
               ],

--- a/docs/lib/pages/docs/icons_page.dart
+++ b/docs/lib/pages/docs/icons_page.dart
@@ -175,7 +175,7 @@ class _IconsPageState extends State<IconsPage> {
                           const Gap(32),
                           TextField(
                             leading: const Icon(Icons.search),
-                            placeholder: const Text('Search icons'),
+                            placeholder: 'Search icons',
                             controller: _controller,
                           ),
                         ],

--- a/lib/src/components/control/command.dart
+++ b/lib/src/components/control/command.dart
@@ -70,7 +70,7 @@ class Command extends StatefulWidget {
   final WidgetBuilder? loadingBuilder;
   final double? surfaceOpacity;
   final double? surfaceBlur;
-  final Widget? searchPlaceholder;
+  final String? searchPlaceholder;
 
   const Command({
     super.key,
@@ -147,7 +147,7 @@ class _CommandState extends State<Command> {
                       border: false,
                       // focusNode: _textFieldFocus,
                       placeholder: widget.searchPlaceholder ??
-                          Text(ShadcnLocalizations.of(context).commandSearch),
+                          ShadcnLocalizations.of(context).commandSearch,
                     ),
                   ),
                   if (canPop)

--- a/lib/src/components/form/autocomplete.dart
+++ b/lib/src/components/form/autocomplete.dart
@@ -11,7 +11,7 @@ class AutoComplete extends StatefulWidget {
   final bool enabled;
   final bool readOnly;
   final List<TextInputFormatter> inputFormatters;
-  final Widget? placeholder;
+  final String? placeholder;
   final ValueChanged<int>? onAcceptSuggestion;
   final FocusNode? focusNode;
   final AlignmentGeometry? popoverAlignment;

--- a/lib/src/components/form/chip_input.dart
+++ b/lib/src/components/form/chip_input.dart
@@ -20,7 +20,7 @@ class ChipInput<T> extends StatefulWidget {
   final ChipWidgetBuilder<T>? suggestionBuilder;
   final bool useChips;
   final TextInputAction? textInputAction;
-  final Widget? placeholder;
+  final String? placeholder;
   final Widget Function(BuildContext, T)? suggestionLeadingBuilder;
   final Widget Function(BuildContext, T)? suggestionTrailingBuilder;
   final Widget? inputTrailingWidget;

--- a/lib/src/components/form/phone_input.dart
+++ b/lib/src/components/form/phone_input.dart
@@ -42,7 +42,7 @@ class PhoneInput extends StatefulWidget {
   final bool filterCountryCode;
   final bool onlyNumber;
   final List<Country>? countries;
-  final Widget? searchPlaceholder;
+  final String? searchPlaceholder;
 
   const PhoneInput({
     super.key,
@@ -142,7 +142,7 @@ class _PhoneInputState extends State<PhoneInput> with FormValueSupplier {
                 bottom: theme.scaling * 8,
                 right: theme.scaling * 4),
             searchPlaceholder: widget.searchPlaceholder ??
-                Text(localization.searchPlaceholderCountry),
+                localization.searchPlaceholderCountry,
             searchFilter: (item, query) {
               query = query.toLowerCase();
               var searchScore = item.name.toLowerCase().contains(query) ||

--- a/lib/src/components/form/select.dart
+++ b/lib/src/components/form/select.dart
@@ -289,7 +289,7 @@ class Select<T> extends StatefulWidget {
   final Widget Function(BuildContext context, T item) itemBuilder;
   final bool showUnrelatedValues;
   final BorderRadiusGeometry? borderRadius;
-  final Widget? searchPlaceholder;
+  final String? searchPlaceholder;
   final EdgeInsetsGeometry? padding;
   final AlignmentGeometry popoverAlignment;
   final AlignmentGeometry? popoverAnchorAlignment;
@@ -518,7 +518,7 @@ class SelectPopup<T> extends StatefulWidget {
   final ValueListenable<List<AbstractSelectItem<T>>> children;
   final bool showUnrelatedValues;
   final SelectValueChanged<T>? onChanged;
-  final Widget? searchPlaceholder;
+  final String? searchPlaceholder;
   final WidgetBuilder? emptyBuilder;
   final bool orderSelectedFirst;
   final double? surfaceBlur;
@@ -892,7 +892,7 @@ class MultiSelect<T> extends StatefulWidget {
   final Widget Function(BuildContext context, T item) itemBuilder;
   final bool showUnrelatedValues;
   final BorderRadiusGeometry? borderRadius;
-  final Widget? searchPlaceholder;
+  final String? searchPlaceholder;
   final EdgeInsetsGeometry? padding;
   final AlignmentGeometry popoverAlignment;
   final AlignmentGeometry? popoverAnchorAlignment;

--- a/lib/src/components/form/text_area.dart
+++ b/lib/src/components/form/text_area.dart
@@ -4,7 +4,7 @@ import 'package:shadcn_flutter/shadcn_flutter.dart';
 class TextArea extends StatefulWidget {
   final TextEditingController? controller;
   final bool filled;
-  final Widget? placeholder;
+  final String? placeholder;
   final bool border;
   final Widget? leading;
   final Widget? trailing;

--- a/lib/src/components/form/text_field.dart
+++ b/lib/src/components/form/text_field.dart
@@ -8,7 +8,7 @@ import '../../../shadcn_flutter.dart';
 class TextField extends StatefulWidget {
   final TextEditingController? controller;
   final bool filled;
-  final Widget? placeholder;
+  final String? placeholder;
   final AlignmentGeometry placeholderAlignment;
   final bool border;
   final Widget? leading;
@@ -191,209 +191,172 @@ class _TextFieldState extends State<TextField> with FormValueSupplier {
     }
     var maxLines = widget.maxLines;
     maxLines ??= widget.obscureText ? 1 : null;
-    return Stack(
-      fit: StackFit.passthrough,
-      children: [
-        material.TextField(
-          key: _key,
-          contextMenuBuilder: widget.contextMenuBuilder == null
-              ? null
-              : widget.useNativeContextMenu && !kIsWeb
-                  ? (context, editableTextState) {
-                      return material.AdaptiveTextSelectionToolbar.editableText(
-                        editableTextState: editableTextState,
-                      );
-                    }
-                  : widget.contextMenuBuilder,
-          clipBehavior: widget.clipBehavior,
-          inputFormatters: widget.inputFormatters,
-          onTapOutside: widget.onTapOutside,
-          onChanged: widget.onChanged,
-          keyboardType: widget.keyboardType,
-          textAlign: widget.textAlign,
-          obscureText: widget.obscureText,
-          autofocus: widget.autofocus,
-          obscuringCharacter: widget.obscuringCharacter,
-          enabled: widget.enabled,
-          readOnly: widget.readOnly,
-          maxLength: widget.maxLength,
-          maxLengthEnforcement: widget.maxLengthEnforcement,
-          maxLines: maxLines,
-          onTap: widget.onTap,
-          focusNode: _focusNode,
-          onSubmitted: widget.onSubmitted,
-          onEditingComplete: widget.onEditingComplete,
-          undoController: _undoHistoryController,
-          textInputAction: widget.textInputAction,
-          autofillHints: widget.autofillHints,
-          minLines: widget.minLines,
-          buildCounter: (context,
-              {required currentLength,
-              required isFocused,
-              required maxLength}) {
-            return null;
-          },
-          controller: _controller,
-          style: defaultTextStyle,
-          expands: widget.expands,
-          textAlignVertical: widget.textAlignVertical,
-          decoration: material.InputDecoration(
-            isCollapsed: widget.isCollapsed,
-            prefixIcon: widget.leading,
-            suffixIcon: widget.trailing,
-            filled: widget.filled,
-            isDense: true,
-            fillColor: theme.colorScheme.muted,
-            // hintText: widget.placeholder,
-            // hintStyle: defaultTextStyle
-            //     .merge(theme.typography.normal)
-            //     .merge(theme.typography.small)
-            //     .copyWith(
-            //       color: theme.colorScheme.mutedForeground,
-            //     ),
-            border: !widget.border
-                ? material.InputBorder.none
-                : widget.filled
-                    ? material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide.none,
-                      )
-                    : material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide(
-                          color: theme.colorScheme.border,
-                        ),
-                      ),
-            hoverColor: Colors.transparent,
-            focusedBorder: !widget.border
-                ? material.InputBorder.none
-                : widget.filled
-                    ? material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide.none,
-                      )
-                    : material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide(
-                          color: theme.colorScheme.ring,
-                        ),
-                      ),
-            enabledBorder: !widget.border
-                ? material.InputBorder.none
-                : widget.filled
-                    ? material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide.none,
-                      )
-                    : material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide(
-                          color: theme.colorScheme.border,
-                        ),
-                      ),
-            disabledBorder: !widget.border
-                ? material.InputBorder.none
-                : widget.filled
-                    ? material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide.none,
-                      )
-                    : material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide(
-                          color: theme.colorScheme.border,
-                        ),
-                      ),
-            errorBorder: !widget.border
-                ? material.InputBorder.none
-                : widget.filled
-                    ? material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide.none,
-                      )
-                    : material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide(
-                          color: theme.colorScheme.destructive,
-                        ),
-                      ),
-            focusedErrorBorder: !widget.border
-                ? material.InputBorder.none
-                : widget.filled
-                    ? material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide.none,
-                      )
-                    : material.OutlineInputBorder(
-                        borderRadius: optionallyResolveBorderRadius(
-                                context, widget.borderRadius) ??
-                            BorderRadius.circular(theme.radiusMd),
-                        borderSide: BorderSide(
-                          color: theme.colorScheme.destructive,
-                        ),
-                      ),
-            contentPadding: widget.padding ??
-                EdgeInsets.symmetric(
-                  horizontal: 12 * scaling,
-                  vertical: (4 + 8) * scaling,
-                ),
-          ),
-          cursorColor: theme.colorScheme.primary,
-          cursorWidth: 1,
-        ),
-        if (widget.placeholder != null)
-          Positioned.fill(
-            child: ListenableBuilder(
-              listenable: _controller,
-              builder: (context, child) {
-                return IgnorePointer(
-                  child: Visibility(
-                    visible: _controller.text.isEmpty,
-                    child: Container(
-                      padding: widget.padding ??
-                          EdgeInsets.symmetric(
-                            horizontal: 12 * scaling,
-                            vertical: (8 + 1) * scaling,
-                          ),
-                      alignment: widget.placeholderAlignment,
-                      child: DefaultTextStyle(
-                        style: defaultTextStyle
-                            .merge(theme.typography.normal)
-                            .merge(theme.typography.small)
-                            .copyWith(
-                              color: theme.colorScheme.mutedForeground,
-                            ),
-                        child: widget.placeholder!,
-                      ),
+    return material.TextField(
+      key: _key,
+      contextMenuBuilder: widget.contextMenuBuilder == null
+          ? null
+          : widget.useNativeContextMenu && !kIsWeb
+              ? (context, editableTextState) {
+                  return material.AdaptiveTextSelectionToolbar.editableText(
+                    editableTextState: editableTextState,
+                  );
+                }
+              : widget.contextMenuBuilder,
+      clipBehavior: widget.clipBehavior,
+      inputFormatters: widget.inputFormatters,
+      onTapOutside: widget.onTapOutside,
+      onChanged: widget.onChanged,
+      keyboardType: widget.keyboardType,
+      textAlign: widget.textAlign,
+      obscureText: widget.obscureText,
+      autofocus: widget.autofocus,
+      obscuringCharacter: widget.obscuringCharacter,
+      enabled: widget.enabled,
+      readOnly: widget.readOnly,
+      maxLength: widget.maxLength,
+      maxLengthEnforcement: widget.maxLengthEnforcement,
+      maxLines: maxLines,
+      onTap: widget.onTap,
+      focusNode: _focusNode,
+      onSubmitted: widget.onSubmitted,
+      onEditingComplete: widget.onEditingComplete,
+      undoController: _undoHistoryController,
+      textInputAction: widget.textInputAction,
+      autofillHints: widget.autofillHints,
+      minLines: widget.minLines,
+      buildCounter: (context,
+          {required currentLength, required isFocused, required maxLength}) {
+        return null;
+      },
+      controller: _controller,
+      style: defaultTextStyle,
+      expands: widget.expands,
+      textAlignVertical: widget.textAlignVertical,
+      decoration: material.InputDecoration(
+        isCollapsed: widget.isCollapsed,
+        prefixIcon: widget.leading,
+        suffixIcon: widget.trailing,
+        filled: widget.filled,
+        isDense: true,
+        fillColor: theme.colorScheme.muted,
+        hintText: widget.placeholder,
+        hintStyle: defaultTextStyle
+            .merge(theme.typography.normal)
+            .merge(theme.typography.small)
+            .copyWith(
+              color: theme.colorScheme.mutedForeground,
+            ),
+        border: !widget.border
+            ? material.InputBorder.none
+            : widget.filled
+                ? material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide.none,
+                  )
+                : material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide(
+                      color: theme.colorScheme.border,
                     ),
                   ),
-                );
-              },
+        hoverColor: Colors.transparent,
+        focusedBorder: !widget.border
+            ? material.InputBorder.none
+            : widget.filled
+                ? material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide.none,
+                  )
+                : material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide(
+                      color: theme.colorScheme.ring,
+                    ),
+                  ),
+        enabledBorder: !widget.border
+            ? material.InputBorder.none
+            : widget.filled
+                ? material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide.none,
+                  )
+                : material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide(
+                      color: theme.colorScheme.border,
+                    ),
+                  ),
+        disabledBorder: !widget.border
+            ? material.InputBorder.none
+            : widget.filled
+                ? material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide.none,
+                  )
+                : material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide(
+                      color: theme.colorScheme.border,
+                    ),
+                  ),
+        errorBorder: !widget.border
+            ? material.InputBorder.none
+            : widget.filled
+                ? material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide.none,
+                  )
+                : material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide(
+                      color: theme.colorScheme.destructive,
+                    ),
+                  ),
+        focusedErrorBorder: !widget.border
+            ? material.InputBorder.none
+            : widget.filled
+                ? material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide.none,
+                  )
+                : material.OutlineInputBorder(
+                    borderRadius: optionallyResolveBorderRadius(
+                            context, widget.borderRadius) ??
+                        BorderRadius.circular(theme.radiusMd),
+                    borderSide: BorderSide(
+                      color: theme.colorScheme.destructive,
+                    ),
+                  ),
+        contentPadding: widget.padding ??
+            EdgeInsets.symmetric(
+              horizontal: 12 * scaling,
+              vertical: (4 + 8) * scaling,
             ),
-          )
-      ],
+      ),
+      cursorColor: theme.colorScheme.primary,
+      cursorWidth: 1,
     );
   }
 }


### PR DESCRIPTION
Basically, Text fields are super buggy the second you try to use leading because theres a hacky-stack instead of using material placeholders (since we're wrapping the mat text field anyway). This actually un-breaks a bunch of ui and doesnt affect any text fields not using leading. 