### PR TITLE
Change Text Field placeholderAlignment AlignmentDirectional.centerStart

### DIFF
--- a/lib/src/components/form/text_field.dart
+++ b/lib/src/components/form/text_field.dart
@@ -84,7 +84,7 @@ class TextField extends StatefulWidget {
     this.textInputAction,
     this.clipBehavior = Clip.hardEdge,
     this.autofocus = false,
-    this.placeholderAlignment = AlignmentDirectional.topStart,
+    this.placeholderAlignment = AlignmentDirectional.centerStart,
   });
 
   static Widget _defaultContextMenuBuilder(


### PR DESCRIPTION
Doesnt affect most text fields, but this fixes when the leading widget is used. 