### PR TITLE
Make text field size to match normal button

### DIFF
--- a/lib/src/components/form/text_field.dart
+++ b/lib/src/components/form/text_field.dart
@@ -229,7 +229,7 @@ class _TextFieldState extends State<TextField> with FormValueSupplier {
                 padding: widget.padding ??
                     EdgeInsets.symmetric(
                       horizontal: 12 * scaling,
-                      vertical: 8 * scaling,
+                      vertical: 6 * scaling,
                     ),
                 child: child,
               ),


### PR DESCRIPTION
The text field was bigger on vertical so i lowered the padding to match the size of the normal button for more consistency