### PR TITLE
fix: color_scheme breaking Flutter >= 3.28.0-0.1.pre

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,6 +53,7 @@ class _CounterPageState extends State<CounterPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      floatingFooter: true,
       headers: [
         AppBar(
           title: const Text('Counter App'),
@@ -105,6 +106,7 @@ class _CounterPageState extends State<CounterPage> {
       footers: [
         const Divider(),
         NavigationBar(
+          surfaceOpacity: 0,
           onSelected: (i) {
             setState(() {
               _selected = i;
@@ -118,26 +120,26 @@ class _CounterPageState extends State<CounterPage> {
           ],
         ),
       ],
-      child: Padding(
+      child: SingleChildScrollView(
         padding: const EdgeInsets.all(32.0),
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              const Text(
-                'You have pushed the button this many times:',
-                textAlign: TextAlign.center,
-              ).p(),
-              Text(
-                '$_counter',
-              ).h1(),
-              PrimaryButton(
-                onPressed: _incrementCounter,
-                density: ButtonDensity.icon,
-                child: const Icon(Icons.add),
-              ).p(),
-            ],
-          ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'You have pushed the button this many times:',
+              textAlign: TextAlign.center,
+            ).p(),
+            Text(
+              '$_counter',
+            ).h1(),
+            PrimaryButton(
+              onPressed: _incrementCounter,
+              density: ButtonDensity.icon,
+              child: const Icon(Icons.add),
+            ).p(),
+            for (int i = 0; i < 20; i++) Text('Item $i').p(),
+            const SafeArea(child: SizedBox()),
+          ],
         ),
       ),
     );

--- a/lib/src/components/display/carousel.dart
+++ b/lib/src/components/display/carousel.dart
@@ -623,7 +623,9 @@ class _CarouselState extends State<Carousel>
   @override
   void dispose() {
     _controller.removeListener(_onControllerChange);
-    _controller.dispose();
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
     _ticker.dispose();
     super.dispose();
   }

--- a/lib/src/components/layout/scaffold.dart
+++ b/lib/src/components/layout/scaffold.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'dart:math' as math;
 
 import 'package:flutter/rendering.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
@@ -158,7 +159,13 @@ class ScaffoldState extends State<Scaffold> {
             buildHeader(context),
             Container(
               padding: viewInsets,
-              child: ToastLayer(child: widget.child),
+              child: ToastLayer(
+                child: _BodyBuilder(
+                  floatingFooter: widget.floatingFooter,
+                  floatingHeader: widget.floatingHeader,
+                  child: widget.child,
+                ),
+              ),
             ),
             buildFooter(context, viewInsets),
           ],
@@ -459,7 +466,16 @@ class _ScaffoldRenderFlex extends RenderBox
         contentOffset = Offset(0, headerSize);
         break;
     }
-    content.layout(contentConstraints, parentUsesSize: true);
+
+    final bodyConstraints = _BodyBoxConstraints(
+      minWidth: contentConstraints.minWidth,
+      maxWidth: contentConstraints.maxWidth,
+      minHeight: contentConstraints.minHeight,
+      maxHeight: contentConstraints.maxHeight,
+      footersHeight: footerSize,
+      headersHeight: headerSize,
+    );
+    content.layout(bodyConstraints, parentUsesSize: true);
     size = constraints.biggest;
     (content.parentData as BoxParentData).offset = contentOffset;
     (footer.parentData as BoxParentData).offset = Offset(
@@ -572,5 +588,119 @@ class _RenderScaffoldPadding extends RenderBox
   @override
   void paint(PaintingContext context, Offset offset) {
     defaultPaint(context, offset);
+  }
+}
+
+class _BodyBoxConstraints extends BoxConstraints {
+  const _BodyBoxConstraints({
+    super.maxWidth,
+    super.maxHeight,
+    super.minWidth,
+    super.minHeight,
+    required this.footersHeight,
+    required this.headersHeight,
+  })  : assert(footersHeight >= 0),
+        assert(headersHeight >= 0);
+
+  final double footersHeight;
+  final double headersHeight;
+
+  @override
+  _BodyBoxConstraints copyWith({
+    double? minWidth,
+    double? maxWidth,
+    double? minHeight,
+    double? maxHeight,
+    double? footersHeight,
+    double? headersHeight,
+  }) {
+    return _BodyBoxConstraints(
+      minWidth: minWidth ?? this.minWidth,
+      maxWidth: maxWidth ?? this.maxWidth,
+      minHeight: minHeight ?? this.minHeight,
+      maxHeight: maxHeight ?? this.maxHeight,
+      footersHeight: footersHeight ?? this.footersHeight,
+      headersHeight: headersHeight ?? this.headersHeight,
+    );
+  }
+
+  @override
+  _BodyBoxConstraints deflate(EdgeInsetsGeometry edges) {
+    final c = super.deflate(edges);
+
+    return _BodyBoxConstraints(
+      minWidth: c.minWidth,
+      maxWidth: c.maxWidth,
+      minHeight: c.minHeight,
+      maxHeight: c.maxHeight,
+      footersHeight: footersHeight,
+      headersHeight: headersHeight,
+    );
+  }
+
+  // RenderObject.layout() will only short-circuit its call to its performLayout
+  // method if the new layout constraints are not == to the current constraints.
+  // If the height of the bottom widgets has changed, even though the constraints'
+  // min and max values have not, we still want performLayout to happen.
+  @override
+  bool operator ==(Object other) {
+    if (super != other) {
+      return false;
+    }
+    return other is _BodyBoxConstraints &&
+        other.footersHeight == footersHeight &&
+        other.headersHeight == headersHeight;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        super.hashCode,
+        footersHeight,
+        headersHeight,
+      );
+}
+
+class _BodyBuilder extends StatelessWidget {
+  const _BodyBuilder({
+    required this.floatingFooter,
+    required this.floatingHeader,
+    required this.child,
+  });
+
+  final Widget child;
+  final bool floatingFooter;
+  final bool floatingHeader;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!floatingFooter && !floatingHeader) {
+      return child;
+    }
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final _BodyBoxConstraints bodyConstraints =
+            constraints as _BodyBoxConstraints;
+        final MediaQueryData metrics = MediaQuery.of(context);
+
+        final double bottom = floatingFooter
+            ? math.max(metrics.padding.bottom, bodyConstraints.footersHeight)
+            : metrics.padding.bottom;
+
+        final double top = floatingHeader
+            ? math.max(metrics.padding.top, bodyConstraints.headersHeight)
+            : metrics.padding.top;
+
+        return MediaQuery(
+          data: metrics.copyWith(
+            padding: metrics.padding.copyWith(
+              top: top,
+              bottom: bottom,
+            ),
+          ),
+          child: child,
+        );
+      },
+    );
   }
 }

--- a/lib/src/theme/color_scheme.dart
+++ b/lib/src/theme/color_scheme.dart
@@ -300,6 +300,19 @@ class ColorShades implements Color, ColorSwatch {
     }
     return ColorShades._direct(colors);
   }
+
+  /// A 32 bit value representing this color.
+  ///
+  /// The bits are assigned as follows:
+  ///
+  /// * Bits 24-31 are the alpha value.
+  /// * Bits 16-23 are the red value.
+  /// * Bits 8-15 are the green value.
+  /// * Bits 0-7 are the blue value.
+  @override
+  int toARGB32() {
+    return value;
+  }
 }
 
 String hexFromColor(Color color) {


### PR DESCRIPTION
Adds `toARGB32` (renamed `value` getter basically) method to make the library compatible with Flutter beta `>= 3.28.0-0.1.pre`
This is a crucial fix that will assist users having #146 issue