### PR TITLE
fix: correct darkZync to darkZinc typo in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ void main() {
       title: 'My App',
       home: MyHomePage(),
       theme: ThemeData(
-        colorScheme: ColorSchemes.darkZync(),
+        colorScheme: ColorSchemes.darkZinc(),
         radius: 0.5,
       ),
     ),

--- a/docs/lib/pages/docs/installation_page.dart
+++ b/docs/lib/pages/docs/installation_page.dart
@@ -113,7 +113,7 @@ void main() {
       title: 'My App',
       home: MyHomePage(),
       theme: ThemeData(
-        colorScheme: ColorSchemes.darkZync(),
+        colorScheme: ColorSchemes.darkZinc(),
         radius: 0.5,
       ),
     ),


### PR DESCRIPTION
From [generated_themes.dart](https://github.com/sunarya-thito/shadcn_flutter/blob/master/lib/src/theme/generated_themes.dart), darkZync does not exist. 
Fixed simple typo