### PR TITLE
Check if mounted before updating children

### DIFF
--- a/lib/src/components/menu/context_menu.dart
+++ b/lib/src/components/menu/context_menu.dart
@@ -436,7 +436,7 @@ class _ContextMenuState extends State<ContextMenu> {
     super.didUpdateWidget(oldWidget);
     if (!listEquals(widget.items, oldWidget.items)) {
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-        _children.value = widget.items;
+        if(mounted) _children.value = widget.items;
       });
     }
   }


### PR DESCRIPTION
This mount check eliminates repeated exceptions I've encounted when placing `ContextMenu` widgets in a `ListView`:

```
A ValueNotifier<List<MenuItem>> was used after being disposed.
...
...
...menu/context_menu.dart:439:19
```