### PR TITLE
Add `background` param to `ShadcnApp` to allow overriding title bar color

### DIFF
--- a/lib/src/shadcn_app.dart
+++ b/lib/src/shadcn_app.dart
@@ -26,6 +26,7 @@ class ShadcnApp extends StatefulWidget {
     this.title = '',
     this.onGenerateTitle,
     this.color,
+    this.background,
     required this.theme,
     this.locale,
     this.localizationsDelegates,
@@ -73,6 +74,7 @@ class ShadcnApp extends StatefulWidget {
     this.onGenerateTitle,
     this.onNavigationNotification,
     this.color,
+    this.background,
     required this.theme,
     this.locale,
     this.localizationsDelegates,
@@ -153,6 +155,7 @@ class ShadcnApp extends StatefulWidget {
   final ThemeData? darkTheme;
   final ThemeMode themeMode;
   final Color? color;
+  final Color? background;
   final Locale? locale;
 
   final Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates;
@@ -439,7 +442,7 @@ class _ShadcnAppState extends State<ShadcnApp> {
                   widget.theme.colorScheme.primaryForeground,
             ),
         child: m.Material(
-          color: m.Colors.transparent,
+          color: widget.background ?? m.Colors.transparent,
           child: m.ScaffoldMessenger(
             child: ScrollConfiguration(
               behavior: (widget.scrollBehavior ?? const ShadcnScrollBehavior()),


### PR DESCRIPTION
Hi, thank you for the great project (and the fantastic documentation)!

This is an extremely simple PR that adds a `background` parameter to `ShadcnApp` and its constructor, to allow overriding the main color of the app's base layer(?). 

### Motivation

The main problem for me was that I could not change the color of the title bar using the [window_manager](https://pub.dev/packages/window_manager) package. I spent some time troubleshooting (calling `WindowManager.setBackgroundColor()` at various points of the lifecycle, etc.) and eventually resorted to editing the `ShadcnApp` constructor. 

**Before**
<img width="1820" alt="_ 2025-07-02 at 2 38 54 AM" src="https://github.com/user-attachments/assets/53195b25-beed-4495-a2d9-0accc4818e13" />

**After**
<img width="1820" alt="_ 2025-07-02 at 4 59 04 AM" src="https://github.com/user-attachments/assets/4a1ab67c-78af-44e3-b167-2f9ef51be6da" />


### Caveats

There probably are solutions to the stubborn title bar color problem that does not involve modifying `shadcn_flutter`; still, `background` seems like a simple and intuitive interface that people can use as a fallback or a quick-and-dirty way to experiment with different app colors (without necessarily modifying the entire theme). Please do feel free to reject it if you don't find this to be the right way to do it!