### PR TITLE
feat: add divider, avatar, progress, card, chip, and more component themes

### DIFF
--- a/lib/src/components/control/hover.dart
+++ b/lib/src/components/control/hover.dart
@@ -1,5 +1,60 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class HoverTheme {
+  final Duration? debounceDuration;
+  final HitTestBehavior? hitTestBehavior;
+  final Duration? waitDuration;
+  final Duration? minDuration;
+  final Duration? showDuration;
+
+  const HoverTheme({
+    this.debounceDuration,
+    this.hitTestBehavior,
+    this.waitDuration,
+    this.minDuration,
+    this.showDuration,
+  });
+
+  HoverTheme copyWith({
+    ValueGetter<Duration?>? debounceDuration,
+    ValueGetter<HitTestBehavior?>? hitTestBehavior,
+    ValueGetter<Duration?>? waitDuration,
+    ValueGetter<Duration?>? minDuration,
+    ValueGetter<Duration?>? showDuration,
+  }) {
+    return HoverTheme(
+      debounceDuration:
+          debounceDuration == null ? this.debounceDuration : debounceDuration(),
+      hitTestBehavior: hitTestBehavior == null
+          ? this.hitTestBehavior
+          : hitTestBehavior(),
+      waitDuration:
+          waitDuration == null ? this.waitDuration : waitDuration(),
+      minDuration: minDuration == null ? this.minDuration : minDuration(),
+      showDuration: showDuration == null ? this.showDuration : showDuration(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is HoverTheme &&
+        other.debounceDuration == debounceDuration &&
+        other.hitTestBehavior == hitTestBehavior &&
+        other.waitDuration == waitDuration &&
+        other.minDuration == minDuration &&
+        other.showDuration == showDuration;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        debounceDuration,
+        hitTestBehavior,
+        waitDuration,
+        minDuration,
+        showDuration,
+      );
+}
+
 /// A widget that tracks the hover state of the mouse cursor
 /// and will call the [onHover] with period of [debounceDuration] when the cursor is hovering over the child widget.
 class HoverActivity extends StatefulWidget {
@@ -7,8 +62,8 @@ class HoverActivity extends StatefulWidget {
   final VoidCallback? onHover;
   final VoidCallback? onExit;
   final VoidCallback? onEnter;
-  final Duration debounceDuration;
-  final HitTestBehavior hitTestBehavior;
+  final Duration? debounceDuration;
+  final HitTestBehavior? hitTestBehavior;
 
   const HoverActivity({
     super.key,
@@ -16,8 +71,8 @@ class HoverActivity extends StatefulWidget {
     this.onHover,
     this.onExit,
     this.onEnter,
-    this.hitTestBehavior = HitTestBehavior.deferToChild,
-    this.debounceDuration = const Duration(milliseconds: 100),
+    this.hitTestBehavior,
+    this.debounceDuration,
   });
 
   @override
@@ -56,8 +111,18 @@ class _HoverActivityState extends State<HoverActivity>
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<HoverTheme>(context);
+    final debounceDuration = styleValue(
+        widgetValue: widget.debounceDuration,
+        themeValue: compTheme?.debounceDuration,
+        defaultValue: const Duration(milliseconds: 100));
+    final behavior = styleValue(
+        widgetValue: widget.hitTestBehavior,
+        themeValue: compTheme?.hitTestBehavior,
+        defaultValue: HitTestBehavior.deferToChild);
+    _controller.duration = debounceDuration;
     return MouseRegion(
-      hitTestBehavior: widget.hitTestBehavior,
+      hitTestBehavior: behavior,
       onEnter: (_) {
         widget.onEnter?.call();
         _controller.repeat(reverse: true);
@@ -74,20 +139,20 @@ class _HoverActivityState extends State<HoverActivity>
 class Hover extends StatefulWidget {
   final Widget child;
   final void Function(bool hovered) onHover;
-  final Duration waitDuration;
-  final Duration
+  final Duration? waitDuration;
+  final Duration?
       minDuration; // The minimum duration to show the hover, if the cursor is quickly moved over the widget.
-  final Duration showDuration; // The duration to show the hover
-  final HitTestBehavior hitTestBehavior;
+  final Duration? showDuration; // The duration to show the hover
+  final HitTestBehavior? hitTestBehavior;
 
   const Hover({
     super.key,
     required this.child,
     required this.onHover,
-    this.waitDuration = const Duration(milliseconds: 500),
-    this.minDuration = const Duration(milliseconds: 0),
-    this.showDuration = const Duration(milliseconds: 200),
-    this.hitTestBehavior = HitTestBehavior.deferToChild,
+    this.waitDuration,
+    this.minDuration,
+    this.showDuration,
+    this.hitTestBehavior,
   });
 
   @override
@@ -97,13 +162,20 @@ class Hover extends StatefulWidget {
 class _HoverState extends State<Hover> with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   int? _enterTime;
+  late Duration _waitDur;
+  late Duration _minDur;
+  late Duration _showDur;
+  late HitTestBehavior _behavior;
 
   @override
   void initState() {
     super.initState();
+    _waitDur = widget.waitDuration ?? const Duration(milliseconds: 500);
+    _minDur = widget.minDuration ?? const Duration(milliseconds: 0);
+    _showDur = widget.showDuration ?? const Duration(milliseconds: 200);
     _controller = AnimationController(
       vsync: this,
-      duration: widget.waitDuration,
+      duration: _waitDur,
     );
     _controller.addStatusListener(_onStatusChanged);
   }
@@ -114,13 +186,13 @@ class _HoverState extends State<Hover> with SingleTickerProviderStateMixin {
   }
 
   void _onExit(bool cursorOut) {
-    int minDuration = widget.minDuration.inMilliseconds;
+    int minDuration = _minDur.inMilliseconds;
     int? enterTime = _enterTime;
     if (enterTime != null) {
       int duration = DateTime.now().millisecondsSinceEpoch - enterTime;
       _controller.reverseDuration = cursorOut
           ? Duration(milliseconds: duration < minDuration ? minDuration : 0)
-          : widget.showDuration;
+          : _showDur;
       _controller.reverse();
     }
     _enterTime = null;
@@ -143,14 +215,34 @@ class _HoverState extends State<Hover> with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final platform = Theme.of(context).platform;
+    final compTheme = ComponentTheme.maybeOf<HoverTheme>(context);
+    _waitDur = styleValue(
+        widgetValue: widget.waitDuration,
+        themeValue: compTheme?.waitDuration,
+        defaultValue: const Duration(milliseconds: 500));
+    _minDur = styleValue(
+        widgetValue: widget.minDuration,
+        themeValue: compTheme?.minDuration,
+        defaultValue: const Duration(milliseconds: 0));
+    _showDur = styleValue(
+        widgetValue: widget.showDuration,
+        themeValue: compTheme?.showDuration,
+        defaultValue: const Duration(milliseconds: 200));
+    _behavior = styleValue(
+        widgetValue: widget.hitTestBehavior,
+        themeValue: compTheme?.hitTestBehavior,
+        defaultValue: HitTestBehavior.deferToChild);
+    _controller.duration = _waitDur;
     bool enableLongPress = platform == TargetPlatform.iOS ||
         platform == TargetPlatform.android ||
         platform == TargetPlatform.fuchsia;
     return TapRegion(
+      behavior: _behavior,
       onTapOutside: (details) {
         _onExit(true);
       },
       child: MouseRegion(
+        hitTestBehavior: _behavior,
         onEnter: (_) => _onEnter(),
         onExit: (_) {
           _onExit(true);

--- a/lib/src/components/control/scrollbar.dart
+++ b/lib/src/components/control/scrollbar.dart
@@ -2,9 +2,54 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
 import '../../../shadcn_flutter.dart';
+
+/// Theme configuration for [Scrollbar].
+class ScrollbarTheme {
+  /// Color of the scrollbar thumb.
+  final Color? color;
+
+  /// Thickness of the scrollbar thumb.
+  final double? thickness;
+
+  /// Radius of the scrollbar thumb.
+  final Radius? radius;
+
+  /// Creates a [ScrollbarTheme].
+  const ScrollbarTheme({
+    this.color,
+    this.thickness,
+    this.radius,
+  });
+
+  /// Creates a copy of this theme with the given values replaced.
+  ScrollbarTheme copyWith({
+    ValueGetter<Color?>? color,
+    ValueGetter<double?>? thickness,
+    ValueGetter<Radius?>? radius,
+  }) {
+    return ScrollbarTheme(
+      color: color == null ? this.color : color(),
+      thickness: thickness == null ? this.thickness : thickness(),
+      radius: radius == null ? this.radius : radius(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScrollbarTheme &&
+        other.color == color &&
+        other.thickness == thickness &&
+        other.radius == radius;
+  }
+
+  @override
+  int get hashCode => Object.hash(color, thickness, radius);
+}
 
 const double _kScrollbarMinLength = 48.0;
 const Duration _kScrollbarFadeDuration = Duration(milliseconds: 300);
@@ -19,6 +64,7 @@ class Scrollbar extends StatelessWidget {
     this.trackVisibility,
     this.thickness,
     this.radius,
+    this.color,
     this.notificationPredicate,
     this.interactive,
     this.scrollbarOrientation,
@@ -31,6 +77,7 @@ class Scrollbar extends StatelessWidget {
   final double? thickness;
 
   final Radius? radius;
+  final Color? color;
 
   final bool? interactive;
   final ScrollNotificationPredicate? notificationPredicate;
@@ -44,6 +91,7 @@ class Scrollbar extends StatelessWidget {
       trackVisibility: trackVisibility,
       thickness: thickness,
       radius: radius,
+      color: color,
       notificationPredicate: notificationPredicate,
       interactive: interactive,
       scrollbarOrientation: scrollbarOrientation,
@@ -60,6 +108,7 @@ class _ShadcnScrollbar extends RawScrollbar {
     super.trackVisibility,
     super.thickness,
     super.radius,
+    this.color,
     ScrollNotificationPredicate? notificationPredicate,
     super.interactive,
     super.scrollbarOrientation,
@@ -70,6 +119,8 @@ class _ShadcnScrollbar extends RawScrollbar {
           notificationPredicate:
               notificationPredicate ?? defaultScrollNotificationPredicate,
         );
+
+  final Color? color;
 
   @override
   _ShadcnScrollbarState createState() => _ShadcnScrollbarState();
@@ -103,14 +154,25 @@ class _ShadcnScrollbarState extends RawScrollbarState<_ShadcnScrollbar> {
 
   @override
   void updateScrollbarPainter() {
+    final compTheme = ComponentTheme.maybeOf<ScrollbarTheme>(context);
     scrollbarPainter
-      ..color = _theme.colorScheme.border
+      ..color = styleValue(
+          widgetValue: widget.color,
+          themeValue: compTheme?.color,
+          defaultValue: _theme.colorScheme.border)
       ..textDirection = Directionality.of(context)
       // Should this be affected by density?
-      ..thickness = 7.0 * _theme.scaling
-      ..radius = widget.radius ?? Radius.circular(_theme.radiusSm)
+      ..thickness = styleValue(
+          widgetValue: widget.thickness,
+          themeValue: compTheme?.thickness,
+          defaultValue: 7.0 * _theme.scaling)
+      ..radius = styleValue(
+          widgetValue: widget.radius,
+          themeValue: compTheme?.radius,
+          defaultValue: Radius.circular(_theme.radiusSm))
       ..minLength = _kScrollbarMinLength
-      ..padding = MediaQuery.paddingOf(context) + EdgeInsets.all(_theme.scaling)
+      ..padding =
+          MediaQuery.paddingOf(context) + EdgeInsets.all(_theme.scaling)
       ..scrollbarOrientation = widget.scrollbarOrientation
       ..ignorePointer = !enableGestures;
   }

--- a/lib/src/components/display/avatar.dart
+++ b/lib/src/components/display/avatar.dart
@@ -1,5 +1,80 @@
 import '../../../shadcn_flutter.dart';
 
+/// A theme for [Avatar].
+class AvatarTheme {
+  /// The default size of the avatar.
+  final double? size;
+
+  /// The border radius of the avatar.
+  final double? borderRadius;
+
+  /// The background color of the avatar.
+  final Color? backgroundColor;
+
+  /// The alignment of the badge relative to the avatar.
+  final AlignmentGeometry? badgeAlignment;
+
+  /// The gap between the avatar and the badge.
+  final double? badgeGap;
+
+  /// The text style of the initials.
+  final TextStyle? textStyle;
+
+  /// Creates a new [AvatarTheme].
+  const AvatarTheme({
+    this.size,
+    this.borderRadius,
+    this.backgroundColor,
+    this.badgeAlignment,
+    this.badgeGap,
+    this.textStyle,
+  });
+
+  /// Creates a copy of this theme but with the given fields replaced with the new values.
+  AvatarTheme copyWith({
+    ValueGetter<double?>? size,
+    ValueGetter<double?>? borderRadius,
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<AlignmentGeometry?>? badgeAlignment,
+    ValueGetter<double?>? badgeGap,
+    ValueGetter<TextStyle?>? textStyle,
+  }) {
+    return AvatarTheme(
+      size: size == null ? this.size : size(),
+      borderRadius:
+          borderRadius == null ? this.borderRadius : borderRadius(),
+      backgroundColor:
+          backgroundColor == null ? this.backgroundColor : backgroundColor(),
+      badgeAlignment:
+          badgeAlignment == null ? this.badgeAlignment : badgeAlignment(),
+      badgeGap: badgeGap == null ? this.badgeGap : badgeGap(),
+      textStyle: textStyle == null ? this.textStyle : textStyle(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AvatarTheme &&
+        other.size == size &&
+        other.borderRadius == borderRadius &&
+        other.backgroundColor == backgroundColor &&
+        other.badgeAlignment == badgeAlignment &&
+        other.badgeGap == badgeGap &&
+        other.textStyle == textStyle;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        size,
+        borderRadius,
+        backgroundColor,
+        badgeAlignment,
+        badgeGap,
+        textStyle,
+      );
+}
+
 abstract class AvatarWidget extends Widget {
   const AvatarWidget({super.key});
 
@@ -81,8 +156,15 @@ class Avatar extends StatefulWidget implements AvatarWidget {
 class _AvatarState extends State<Avatar> {
   Widget _build(BuildContext context) {
     final theme = Theme.of(context);
-    double size = widget.size ?? (theme.scaling * 40);
-    double borderRadius = widget.borderRadius ?? theme.radius * size;
+    final compTheme = ComponentTheme.maybeOf<AvatarTheme>(context);
+    double size = styleValue(
+        widgetValue: widget.size,
+        themeValue: compTheme?.size,
+        defaultValue: theme.scaling * 40);
+    double borderRadius = styleValue(
+        widgetValue: widget.borderRadius,
+        themeValue: compTheme?.borderRadius,
+        defaultValue: theme.radius * size);
     if (widget.provider != null) {
       return SizedBox(
         width: size,
@@ -108,9 +190,13 @@ class _AvatarState extends State<Avatar> {
 
   Widget _buildInitials(BuildContext context, double borderRadius) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<AvatarTheme>(context);
     return Container(
       decoration: BoxDecoration(
-        color: widget.backgroundColor ?? theme.colorScheme.muted,
+        color: styleValue(
+            widgetValue: widget.backgroundColor,
+            themeValue: compTheme?.backgroundColor,
+            defaultValue: theme.colorScheme.muted),
         borderRadius: BorderRadius.circular(borderRadius),
       ),
       child: FittedBox(
@@ -123,9 +209,12 @@ class _AvatarState extends State<Avatar> {
                 widget.initials,
               ),
             ),
-            style: TextStyle(
-              color: theme.colorScheme.foreground,
-              fontWeight: FontWeight.bold,
+            style: styleValue(
+              themeValue: compTheme?.textStyle,
+              defaultValue: TextStyle(
+                color: theme.colorScheme.foreground,
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ),
         ),
@@ -139,13 +228,29 @@ class _AvatarState extends State<Avatar> {
       return _build(context);
     }
     final theme = Theme.of(context);
-    double size = widget.size ?? theme.scaling * 40;
+    final compTheme = ComponentTheme.maybeOf<AvatarTheme>(context);
+    double size = styleValue(
+        widgetValue: widget.size,
+        themeValue: compTheme?.size,
+        defaultValue: theme.scaling * 40);
+    double borderRadius = styleValue(
+        widgetValue: widget.borderRadius,
+        themeValue: compTheme?.borderRadius,
+        defaultValue: theme.radius * size);
     double badgeSize = widget.badge!.size ?? theme.scaling * 12;
     double offset = size / 2 - badgeSize / 2;
     offset = offset / size;
+    final alignment = styleValue(
+        widgetValue: widget.badgeAlignment,
+        themeValue: compTheme?.badgeAlignment,
+        defaultValue: AlignmentDirectional(offset, offset));
+    final gap = styleValue(
+        widgetValue: widget.badgeGap,
+        themeValue: compTheme?.badgeGap,
+        defaultValue: theme.scaling * 4);
     return AvatarGroup(
-      alignment: widget.badgeAlignment ?? AlignmentDirectional(offset, offset),
-      gap: widget.badgeGap ?? theme.scaling * 4,
+      alignment: alignment,
+      gap: gap,
       children: [
         _AvatarWidget(
           size: widget.badge!.size ?? theme.scaling * 12,
@@ -153,8 +258,8 @@ class _AvatarState extends State<Avatar> {
           child: widget.badge!,
         ),
         _AvatarWidget(
-          size: widget.size,
-          borderRadius: widget.borderRadius,
+          size: size,
+          borderRadius: borderRadius,
           child: _build(context),
         ),
       ],

--- a/lib/src/components/display/badge.dart
+++ b/lib/src/components/display/badge.dart
@@ -1,5 +1,62 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [PrimaryBadge], [SecondaryBadge], [OutlineBadge], and
+/// [DestructiveBadge].
+class BadgeTheme {
+  /// Style for [PrimaryBadge].
+  final AbstractButtonStyle? primaryStyle;
+
+  /// Style for [SecondaryBadge].
+  final AbstractButtonStyle? secondaryStyle;
+
+  /// Style for [OutlineBadge].
+  final AbstractButtonStyle? outlineStyle;
+
+  /// Style for [DestructiveBadge].
+  final AbstractButtonStyle? destructiveStyle;
+
+  /// Creates a [BadgeTheme].
+  const BadgeTheme({
+    this.primaryStyle,
+    this.secondaryStyle,
+    this.outlineStyle,
+    this.destructiveStyle,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  BadgeTheme copyWith({
+    ValueGetter<AbstractButtonStyle?>? primaryStyle,
+    ValueGetter<AbstractButtonStyle?>? secondaryStyle,
+    ValueGetter<AbstractButtonStyle?>? outlineStyle,
+    ValueGetter<AbstractButtonStyle?>? destructiveStyle,
+  }) {
+    return BadgeTheme(
+      primaryStyle: primaryStyle == null ? this.primaryStyle : primaryStyle(),
+      secondaryStyle: secondaryStyle == null
+          ? this.secondaryStyle
+          : secondaryStyle(),
+      outlineStyle: outlineStyle == null ? this.outlineStyle : outlineStyle(),
+      destructiveStyle: destructiveStyle == null
+          ? this.destructiveStyle
+          : destructiveStyle(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is BadgeTheme &&
+        other.primaryStyle == primaryStyle &&
+        other.secondaryStyle == secondaryStyle &&
+        other.outlineStyle == outlineStyle &&
+        other.destructiveStyle == destructiveStyle;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(primaryStyle, secondaryStyle, outlineStyle, destructiveStyle);
+}
+
 class PrimaryBadge extends StatelessWidget {
   final Widget child;
   final VoidCallback? onPressed;
@@ -18,24 +75,26 @@ class PrimaryBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<BadgeTheme>(context);
+    final baseStyle =
+        style ??
+        compTheme?.primaryStyle ??
+        const ButtonStyle.primary(
+          size: ButtonSize.small,
+          density: ButtonDensity.dense,
+          shape: ButtonShape.rectangle,
+        ).copyWith(
+          textStyle: (context, states, value) {
+            return value.copyWith(fontWeight: FontWeight.w500);
+          },
+        );
     return ExcludeFocus(
       child: Button(
         leading: leading,
         trailing: trailing,
         onPressed: onPressed,
         enabled: true,
-        style: style ??
-            const ButtonStyle.primary(
-              size: ButtonSize.small,
-              density: ButtonDensity.dense,
-              shape: ButtonShape.rectangle,
-            ).copyWith(
-              textStyle: (context, states, value) {
-                return value.copyWith(
-                  fontWeight: FontWeight.w500,
-                );
-              },
-            ),
+        style: baseStyle,
         child: child,
       ),
     );
@@ -60,24 +119,26 @@ class SecondaryBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<BadgeTheme>(context);
+    final baseStyle =
+        style ??
+        compTheme?.secondaryStyle ??
+        const ButtonStyle.secondary(
+          size: ButtonSize.small,
+          density: ButtonDensity.dense,
+          shape: ButtonShape.rectangle,
+        ).copyWith(
+          textStyle: (context, states, value) {
+            return value.copyWith(fontWeight: FontWeight.w500);
+          },
+        );
     return ExcludeFocus(
       child: Button(
         leading: leading,
         trailing: trailing,
         onPressed: onPressed,
         enabled: true,
-        style: style ??
-            const ButtonStyle.secondary(
-              size: ButtonSize.small,
-              density: ButtonDensity.dense,
-              shape: ButtonShape.rectangle,
-            ).copyWith(
-              textStyle: (context, states, value) {
-                return value.copyWith(
-                  fontWeight: FontWeight.w500,
-                );
-              },
-            ),
+        style: baseStyle,
         child: child,
       ),
     );
@@ -102,24 +163,26 @@ class OutlineBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<BadgeTheme>(context);
+    final baseStyle =
+        style ??
+        compTheme?.outlineStyle ??
+        const ButtonStyle.outline(
+          size: ButtonSize.small,
+          density: ButtonDensity.dense,
+          shape: ButtonShape.rectangle,
+        ).copyWith(
+          textStyle: (context, states, value) {
+            return value.copyWith(fontWeight: FontWeight.w500);
+          },
+        );
     return ExcludeFocus(
       child: Button(
         leading: leading,
         trailing: trailing,
         onPressed: onPressed,
         enabled: true,
-        style: style ??
-            const ButtonStyle.outline(
-              size: ButtonSize.small,
-              density: ButtonDensity.dense,
-              shape: ButtonShape.rectangle,
-            ).copyWith(
-              textStyle: (context, states, value) {
-                return value.copyWith(
-                  fontWeight: FontWeight.w500,
-                );
-              },
-            ),
+        style: baseStyle,
         child: child,
       ),
     );
@@ -144,24 +207,26 @@ class DestructiveBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<BadgeTheme>(context);
+    final baseStyle =
+        style ??
+        compTheme?.destructiveStyle ??
+        const ButtonStyle.destructive(
+          size: ButtonSize.small,
+          density: ButtonDensity.dense,
+          shape: ButtonShape.rectangle,
+        ).copyWith(
+          textStyle: (context, states, value) {
+            return value.copyWith(fontWeight: FontWeight.w500);
+          },
+        );
     return ExcludeFocus(
       child: Button(
         leading: leading,
         trailing: trailing,
         onPressed: onPressed,
         enabled: true,
-        style: style ??
-            const ButtonStyle.destructive(
-              size: ButtonSize.small,
-              density: ButtonDensity.dense,
-              shape: ButtonShape.rectangle,
-            ).copyWith(
-              textStyle: (context, states, value) {
-                return value.copyWith(
-                  fontWeight: FontWeight.w500,
-                );
-              },
-            ),
+        style: baseStyle,
         child: child,
       ),
     );

--- a/lib/src/components/display/chip.dart
+++ b/lib/src/components/display/chip.dart
@@ -1,5 +1,39 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [Chip].
+class ChipTheme {
+  /// The padding inside the chip.
+  final EdgeInsetsGeometry? padding;
+
+  /// The default [Button] style of the chip.
+  final AbstractButtonStyle? style;
+
+  /// Creates a [ChipTheme].
+  const ChipTheme({this.padding, this.style});
+
+  /// Creates a copy of this theme with the given values replaced.
+  ChipTheme copyWith({
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<AbstractButtonStyle?>? style,
+  }) {
+    return ChipTheme(
+      padding: padding == null ? this.padding : padding(),
+      style: style == null ? this.style : style(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ChipTheme &&
+        other.padding == padding &&
+        other.style == style;
+  }
+
+  @override
+  int get hashCode => Object.hash(padding, style);
+}
+
 class ChipButton extends StatelessWidget {
   final Widget child;
   final VoidCallback? onPressed;
@@ -13,30 +47,37 @@ class ChipButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<ChipTheme>(context);
+    final padding = styleValue(
+      themeValue: compTheme?.padding,
+      defaultValue: EdgeInsets.zero,
+    );
+    final style = compTheme?.style ??
+        ButtonVariance(
+          decoration: (context, states) {
+            return const BoxDecoration();
+          },
+          mouseCursor: (context, states) {
+            if (states.contains(WidgetState.disabled)) {
+              return SystemMouseCursors.basic;
+            }
+            return SystemMouseCursors.click;
+          },
+          padding: (context, states) {
+            return padding;
+          },
+          textStyle: (context, states) {
+            return const TextStyle();
+          },
+          iconTheme: (context, states) {
+            return theme.iconTheme.xSmall;
+          },
+          margin: (context, states) {
+            return EdgeInsets.zero;
+          },
+        );
     return Button(
-      style: ButtonVariance(
-        decoration: (context, states) {
-          return const BoxDecoration();
-        },
-        mouseCursor: (context, states) {
-          if (states.contains(WidgetState.disabled)) {
-            return SystemMouseCursors.basic;
-          }
-          return SystemMouseCursors.click;
-        },
-        padding: (context, states) {
-          return EdgeInsets.zero;
-        },
-        textStyle: (context, states) {
-          return const TextStyle();
-        },
-        iconTheme: (context, states) {
-          return theme.iconTheme.xSmall;
-        },
-        margin: (context, states) {
-          return EdgeInsets.zero;
-        },
-      ),
+      style: style,
       onPressed: onPressed,
       child: child,
     );
@@ -62,16 +103,25 @@ class Chip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<ChipTheme>(context);
+    final baseStyle = style ?? compTheme?.style ?? ButtonVariance.secondary;
     return Button(
-      style: (style ?? ButtonVariance.secondary).copyWith(
+      style: baseStyle.copyWith(
         mouseCursor: (context, states, value) {
           return onPressed != null
               ? SystemMouseCursors.click
               : SystemMouseCursors.basic;
         },
         padding: (context, states, value) {
-          return EdgeInsets.symmetric(
-              horizontal: theme.scaling * 8, vertical: theme.scaling * 4);
+          final widgetPadding = style?.padding?.call(context, states);
+          return styleValue(
+            widgetValue: widgetPadding,
+            themeValue: compTheme?.padding,
+            defaultValue: EdgeInsets.symmetric(
+              horizontal: theme.scaling * 8,
+              vertical: theme.scaling * 4,
+            ),
+          );
         },
       ),
       onPressed: onPressed ?? () {},

--- a/lib/src/components/display/circular_progress_indicator.dart
+++ b/lib/src/components/display/circular_progress_indicator.dart
@@ -2,9 +2,76 @@ import 'package:flutter/material.dart' as mat;
 
 import '../../../shadcn_flutter.dart';
 
+/// Theme data for [CircularProgressIndicator].
+class CircularProgressIndicatorTheme {
+  /// Color of the progress indicator.
+  final Color? color;
+
+  /// Background color of the progress indicator.
+  final Color? backgroundColor;
+
+  /// Size of the progress indicator.
+  final double? size;
+
+  /// Stroke width of the progress indicator.
+  final double? strokeWidth;
+
+  const CircularProgressIndicatorTheme({
+    this.color,
+    this.backgroundColor,
+    this.size,
+    this.strokeWidth,
+  });
+
+  CircularProgressIndicatorTheme copyWith({
+    ValueGetter<Color?>? color,
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<double?>? size,
+    ValueGetter<double?>? strokeWidth,
+  }) {
+    return CircularProgressIndicatorTheme(
+      color: color == null ? this.color : color(),
+      backgroundColor:
+          backgroundColor == null ? this.backgroundColor : backgroundColor(),
+      size: size == null ? this.size : size(),
+      strokeWidth: strokeWidth == null ? this.strokeWidth : strokeWidth(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CircularProgressIndicatorTheme &&
+        other.color == color &&
+        other.backgroundColor == backgroundColor &&
+        other.size == size &&
+        other.strokeWidth == strokeWidth;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        color,
+        backgroundColor,
+        size,
+        strokeWidth,
+      );
+}
+
 class CircularProgressIndicator extends StatelessWidget {
   final double? value;
+
+  /// Explicit size for the indicator.
   final double? size;
+
+  /// Color of the indicator.
+  final Color? color;
+
+  /// Background color of the indicator.
+  final Color? backgroundColor;
+
+  /// Stroke width of the indicator.
+  final double? strokeWidth;
+
   final Duration duration;
   final bool animated;
   final bool onSurface;
@@ -13,6 +80,9 @@ class CircularProgressIndicator extends StatelessWidget {
     super.key,
     this.value,
     this.size,
+    this.color,
+    this.backgroundColor,
+    this.strokeWidth,
     this.duration = kDefaultDuration,
     this.animated = true,
     this.onSurface = false,
@@ -22,23 +92,42 @@ class CircularProgressIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     final iconThemeData = IconTheme.of(context);
     final theme = Theme.of(context);
-    var color =
-        onSurface ? theme.colorScheme.background : theme.colorScheme.primary;
+    final compTheme =
+        ComponentTheme.maybeOf<CircularProgressIndicatorTheme>(context);
+
+    final effectiveSize = styleValue(
+        widgetValue: size,
+        themeValue: compTheme?.size,
+        defaultValue:
+            (iconThemeData.size ?? 24 * theme.scaling) - 8 * theme.scaling);
+
+    final effectiveColor = styleValue(
+        widgetValue: color,
+        themeValue: compTheme?.color,
+        defaultValue: onSurface
+            ? theme.colorScheme.background
+            : theme.colorScheme.primary);
+
+    final effectiveBackgroundColor = styleValue(
+        widgetValue: backgroundColor,
+        themeValue: compTheme?.backgroundColor,
+        defaultValue: effectiveColor.scaleAlpha(0.2));
+
+    final effectiveStrokeWidth = styleValue(
+        widgetValue: strokeWidth,
+        themeValue: compTheme?.strokeWidth,
+        defaultValue: effectiveSize / 12);
+
     if (value == null || !animated) {
       return RepaintBoundary(
         child: SizedBox(
-          width: size ??
-              (iconThemeData.size ?? 24 * theme.scaling) - 8 * theme.scaling,
-          height: size ??
-              (iconThemeData.size ?? 24 * theme.scaling) - 8 * theme.scaling,
+          width: effectiveSize,
+          height: effectiveSize,
           child: mat.CircularProgressIndicator(
-            valueColor: AlwaysStoppedAnimation<Color>(
-              color,
-            ),
-            color: color,
-            backgroundColor: color.scaleAlpha(0.2),
-            strokeWidth:
-                (size ?? (iconThemeData.size ?? (theme.scaling * 24))) / 12,
+            valueColor: AlwaysStoppedAnimation<Color>(effectiveColor),
+            color: effectiveColor,
+            backgroundColor: effectiveBackgroundColor,
+            strokeWidth: effectiveStrokeWidth,
             value: value,
           ),
         ),
@@ -50,20 +139,13 @@ class CircularProgressIndicator extends StatelessWidget {
         builder: (context, value, child) {
           return RepaintBoundary(
             child: SizedBox(
-              width: size ??
-                  (iconThemeData.size ?? (theme.scaling * 24)) -
-                      (theme.scaling * 8),
-              height: size ??
-                  (iconThemeData.size ?? (theme.scaling * 24)) -
-                      (theme.scaling * 8),
+              width: effectiveSize,
+              height: effectiveSize,
               child: mat.CircularProgressIndicator(
-                valueColor: AlwaysStoppedAnimation<Color>(
-                  color,
-                ),
-                color: color,
-                backgroundColor: color.scaleAlpha(0.2),
-                strokeWidth:
-                    (size ?? (iconThemeData.size ?? (theme.scaling * 24))) / 12,
+                valueColor: AlwaysStoppedAnimation<Color>(effectiveColor),
+                color: effectiveColor,
+                backgroundColor: effectiveBackgroundColor,
+                strokeWidth: effectiveStrokeWidth,
                 value: value,
               ),
             ),

--- a/lib/src/components/display/code_snippet.dart
+++ b/lib/src/components/display/code_snippet.dart
@@ -3,6 +3,71 @@ import 'package:syntax_highlight/syntax_highlight.dart';
 
 import '../../../shadcn_flutter.dart';
 
+/// Theme for [CodeSnippet].
+class CodeSnippetTheme {
+  /// Background color of the snippet container.
+  final Color? backgroundColor;
+
+  /// Border color of the snippet container.
+  final Color? borderColor;
+
+  /// Border width of the snippet container.
+  final double? borderWidth;
+
+  /// Border radius of the snippet container.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Padding for the code content.
+  final EdgeInsetsGeometry? padding;
+
+  /// Creates a [CodeSnippetTheme].
+  const CodeSnippetTheme({
+    this.backgroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.borderRadius,
+    this.padding,
+  });
+
+  /// Creates a copy of this theme with the given values replaced.
+  CodeSnippetTheme copyWith({
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<Color?>? borderColor,
+    ValueGetter<double?>? borderWidth,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+  }) {
+    return CodeSnippetTheme(
+      backgroundColor:
+          backgroundColor == null ? this.backgroundColor : backgroundColor(),
+      borderColor: borderColor == null ? this.borderColor : borderColor(),
+      borderWidth: borderWidth == null ? this.borderWidth : borderWidth(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+      padding: padding == null ? this.padding : padding(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CodeSnippetTheme &&
+        other.backgroundColor == backgroundColor &&
+        other.borderColor == borderColor &&
+        other.borderWidth == borderWidth &&
+        other.borderRadius == borderRadius &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        backgroundColor,
+        borderColor,
+        borderWidth,
+        borderRadius,
+        padding,
+      );
+}
+
 class CodeSnippet extends StatefulWidget {
   final BoxConstraints? constraints;
   final String code;
@@ -99,14 +164,41 @@ class _CodeSnippetState extends State<CodeSnippet> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<CodeSnippetTheme>(context);
+    final backgroundColor = styleValue(
+      themeValue: compTheme?.backgroundColor,
+      defaultValue: theme.colorScheme.card,
+    );
+    final borderColor = styleValue(
+      themeValue: compTheme?.borderColor,
+      defaultValue: theme.colorScheme.border,
+    );
+    final borderWidth = styleValue(
+      themeValue: compTheme?.borderWidth,
+      defaultValue: theme.scaling,
+    );
+    final borderRadius = styleValue(
+      themeValue: compTheme?.borderRadius,
+      defaultValue: BorderRadius.circular(theme.radiusLg),
+    );
+    final padding = styleValue(
+      themeValue: compTheme?.padding,
+      defaultValue: EdgeInsets.only(
+        left: theme.scaling * 16,
+        right: theme.scaling * 48,
+        top: theme.scaling * 16,
+        bottom: theme.scaling * 16,
+      ),
+    );
+
     return Container(
       decoration: BoxDecoration(
-        color: theme.colorScheme.card,
+        color: backgroundColor,
         border: Border.all(
-          color: theme.colorScheme.border,
-          width: theme.scaling,
+          color: borderColor,
+          width: borderWidth,
         ),
-        borderRadius: BorderRadius.circular(theme.radiusLg),
+        borderRadius: borderRadius,
       ),
       child: Stack(
         fit: StackFit.passthrough,
@@ -127,12 +219,7 @@ class _CodeSnippetState extends State<CodeSnippet> {
                   child: SingleChildScrollView(
                     child: SingleChildScrollView(
                       scrollDirection: Axis.horizontal,
-                      padding: EdgeInsets.only(
-                        left: theme.scaling * 16,
-                        right: theme.scaling * 48,
-                        top: theme.scaling * 16,
-                        bottom: theme.scaling * 16,
-                      ),
+                      padding: padding,
                       child: data == null
                           ? SelectableText(widget.code).muted().mono().small()
                           : SelectableText.rich(

--- a/lib/src/components/display/divider.dart
+++ b/lib/src/components/display/divider.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'package:flutter/foundation.dart';
 
 import '../../../shadcn_flutter.dart';
 
@@ -24,6 +25,71 @@ class DividerProperties {
       endIndent: lerpDouble(a.endIndent, b.endIndent, t)!,
     );
   }
+}
+
+/// Theme configuration for [Divider].
+class DividerTheme {
+  /// Color of the divider line.
+  final Color? color;
+
+  /// Height of the divider widget.
+  final double? height;
+
+  /// Thickness of the divider line.
+  final double? thickness;
+
+  /// Empty space to the leading edge of the divider.
+  final double? indent;
+
+  /// Empty space to the trailing edge of the divider.
+  final double? endIndent;
+
+  /// Padding around the [Divider.child].
+  final EdgeInsetsGeometry? padding;
+
+  /// Creates a [DividerTheme].
+  const DividerTheme({
+    this.color,
+    this.height,
+    this.thickness,
+    this.indent,
+    this.endIndent,
+    this.padding,
+  });
+
+  /// Creates a copy of this theme but with the given fields replaced by the
+  /// new values.
+  DividerTheme copyWith({
+    ValueGetter<Color?>? color,
+    ValueGetter<double?>? height,
+    ValueGetter<double?>? thickness,
+    ValueGetter<double?>? indent,
+    ValueGetter<double?>? endIndent,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+  }) {
+    return DividerTheme(
+      color: color == null ? this.color : color(),
+      height: height == null ? this.height : height(),
+      thickness: thickness == null ? this.thickness : thickness(),
+      indent: indent == null ? this.indent : indent(),
+      endIndent: endIndent == null ? this.endIndent : endIndent(),
+      padding: padding == null ? this.padding : padding(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is DividerTheme &&
+      color == other.color &&
+      height == other.height &&
+      thickness == other.thickness &&
+      indent == other.indent &&
+      endIndent == other.endIndent &&
+      padding == other.padding;
+
+  @override
+  int get hashCode =>
+      Object.hash(color, height, thickness, indent, endIndent, padding);
 }
 
 class Divider extends StatelessWidget implements PreferredSizeWidget {
@@ -52,6 +118,37 @@ class Divider extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<DividerTheme>(context);
+    final color = styleValue(
+      widgetValue: this.color,
+      themeValue: compTheme?.color,
+      defaultValue: theme.colorScheme.border,
+    );
+    final thickness = styleValue(
+      widgetValue: this.thickness,
+      themeValue: compTheme?.thickness,
+      defaultValue: 1,
+    );
+    final height = styleValue(
+      widgetValue: this.height,
+      themeValue: compTheme?.height,
+      defaultValue: thickness,
+    );
+    final indent = styleValue(
+      widgetValue: this.indent,
+      themeValue: compTheme?.indent,
+      defaultValue: 0,
+    );
+    final endIndent = styleValue(
+      widgetValue: this.endIndent,
+      themeValue: compTheme?.endIndent,
+      defaultValue: 0,
+    );
+    final padding = styleValue(
+      widgetValue: this.padding,
+      themeValue: compTheme?.padding,
+      defaultValue: EdgeInsets.symmetric(horizontal: theme.scaling * 8),
+    );
     if (child != null) {
       return SizedBox(
         width: double.infinity,
@@ -61,12 +158,12 @@ class Divider extends StatelessWidget implements PreferredSizeWidget {
             children: [
               Expanded(
                 child: SizedBox(
-                  height: height ?? 1,
+                  height: height,
                   child: AnimatedValueBuilder(
                       value: DividerProperties(
-                        color: color ?? theme.colorScheme.border,
-                        thickness: thickness ?? 1,
-                        indent: indent ?? 0,
+                        color: color,
+                        thickness: thickness,
+                        indent: indent,
                         endIndent: 0,
                       ),
                       duration: kDefaultDuration,
@@ -83,18 +180,19 @@ class Divider extends StatelessWidget implements PreferredSizeWidget {
                       }),
                 ),
               ),
-              child!.muted().small().withPadding(
-                  padding: padding ??
-                      EdgeInsets.symmetric(horizontal: theme.scaling * 8)),
+              child!
+                  .muted()
+                  .small()
+                  .withPadding(padding: padding),
               Expanded(
                 child: SizedBox(
-                  height: height ?? 1,
+                  height: height,
                   child: AnimatedValueBuilder(
                       value: DividerProperties(
-                        color: color ?? theme.colorScheme.border,
-                        thickness: thickness ?? 1,
+                        color: color,
+                        thickness: thickness,
                         indent: 0,
-                        endIndent: endIndent ?? 0,
+                        endIndent: endIndent,
                       ),
                       duration: kDefaultDuration,
                       lerp: DividerProperties.lerp,
@@ -116,14 +214,14 @@ class Divider extends StatelessWidget implements PreferredSizeWidget {
       );
     }
     return SizedBox(
-      height: height ?? 1,
+      height: height,
       width: double.infinity,
       child: AnimatedValueBuilder(
           value: DividerProperties(
-            color: color ?? theme.colorScheme.border,
-            thickness: thickness ?? 1,
-            indent: indent ?? 0,
-            endIndent: endIndent ?? 0,
+            color: color,
+            thickness: thickness,
+            indent: indent,
+            endIndent: endIndent,
           ),
           lerp: DividerProperties.lerp,
           duration: kDefaultDuration,

--- a/lib/src/components/display/dot_indicator.dart
+++ b/lib/src/components/display/dot_indicator.dart
@@ -1,7 +1,108 @@
+import 'package:flutter/foundation.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
 typedef DotBuilder = Widget Function(
     BuildContext context, int index, bool active);
+
+/// Theme configuration for [DotIndicator] and its dot items.
+class DotIndicatorTheme {
+  /// Spacing between dots.
+  final double? spacing;
+
+  /// Padding around the dots container.
+  final EdgeInsetsGeometry? padding;
+
+  /// Builder for individual dots.
+  final DotBuilder? dotBuilder;
+
+  /// Size of each dot.
+  final double? size;
+
+  /// Border radius of dots.
+  final double? borderRadius;
+
+  /// Color of the active dot.
+  final Color? activeColor;
+
+  /// Color of the inactive dot.
+  final Color? inactiveColor;
+
+  /// Border color of the inactive dot.
+  final Color? inactiveBorderColor;
+
+  /// Border width of the inactive dot.
+  final double? inactiveBorderWidth;
+
+  /// Creates a [DotIndicatorTheme].
+  const DotIndicatorTheme({
+    this.spacing,
+    this.padding,
+    this.dotBuilder,
+    this.size,
+    this.borderRadius,
+    this.activeColor,
+    this.inactiveColor,
+    this.inactiveBorderColor,
+    this.inactiveBorderWidth,
+  });
+
+  /// Creates a copy of this theme but with the given fields replaced.
+  DotIndicatorTheme copyWith({
+    ValueGetter<double?>? spacing,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<DotBuilder?>? dotBuilder,
+    ValueGetter<double?>? size,
+    ValueGetter<double?>? borderRadius,
+    ValueGetter<Color?>? activeColor,
+    ValueGetter<Color?>? inactiveColor,
+    ValueGetter<Color?>? inactiveBorderColor,
+    ValueGetter<double?>? inactiveBorderWidth,
+  }) {
+    return DotIndicatorTheme(
+      spacing: spacing == null ? this.spacing : spacing(),
+      padding: padding == null ? this.padding : padding(),
+      dotBuilder: dotBuilder == null ? this.dotBuilder : dotBuilder(),
+      size: size == null ? this.size : size(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+      activeColor: activeColor == null ? this.activeColor : activeColor(),
+      inactiveColor:
+          inactiveColor == null ? this.inactiveColor : inactiveColor(),
+      inactiveBorderColor: inactiveBorderColor == null
+          ? this.inactiveBorderColor
+          : inactiveBorderColor(),
+      inactiveBorderWidth: inactiveBorderWidth == null
+          ? this.inactiveBorderWidth
+          : inactiveBorderWidth(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DotIndicatorTheme &&
+        other.spacing == spacing &&
+        other.padding == padding &&
+        other.dotBuilder == dotBuilder &&
+        other.size == size &&
+        other.borderRadius == borderRadius &&
+        other.activeColor == activeColor &&
+        other.inactiveColor == inactiveColor &&
+        other.inactiveBorderColor == inactiveBorderColor &&
+        other.inactiveBorderWidth == inactiveBorderWidth;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      spacing,
+      padding,
+      dotBuilder,
+      size,
+      borderRadius,
+      activeColor,
+      inactiveColor,
+      inactiveBorderColor,
+      inactiveBorderWidth);
+}
 
 class DotIndicator extends StatelessWidget {
   static Widget _defaultDotBuilder(
@@ -33,11 +134,19 @@ class DotIndicator extends StatelessWidget {
     final theme = Theme.of(context);
     final directionality = Directionality.of(context);
     final scaling = theme.scaling;
-    final spacing = this.spacing ?? (8 * scaling);
-    final padding =
-        (this.padding ?? const EdgeInsets.all(8)).resolve(directionality) *
-            theme.scaling;
-    final dotBuilder = this.dotBuilder ?? _defaultDotBuilder;
+    final compTheme = ComponentTheme.maybeOf<DotIndicatorTheme>(context);
+    final spacing = styleValue(
+        widgetValue: this.spacing,
+        themeValue: compTheme?.spacing,
+        defaultValue: 8 * scaling);
+    final padding = styleValue(
+            widgetValue: this.padding,
+            themeValue: compTheme?.padding,
+            defaultValue: const EdgeInsets.all(8))
+        .resolve(directionality) *
+        theme.scaling;
+    final dotBuilder =
+        this.dotBuilder ?? compTheme?.dotBuilder ?? _defaultDotBuilder;
     List<Widget> children = [];
     for (int i = 0; i < length; i++) {
       double topPadding = padding.top;
@@ -126,10 +235,22 @@ class ActiveDotItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<DotIndicatorTheme>(context);
     final scaling = theme.scaling;
-    final size = this.size ?? (12 * scaling);
-    final color = this.color ?? theme.colorScheme.primary;
-    final borderRadius = this.borderRadius ?? theme.radiusMd;
+    final size = styleValue(
+        widgetValue: this.size,
+        themeValue: compTheme?.size,
+        defaultValue: 12 * scaling);
+    final color = styleValue(
+        widgetValue: this.color,
+        themeValue: compTheme?.activeColor,
+        defaultValue: theme.colorScheme.primary);
+    final borderRadius = styleValue(
+        widgetValue: this.borderRadius,
+        themeValue: compTheme?.borderRadius,
+        defaultValue: theme.radiusMd);
+    final borderColor = this.borderColor;
+    final borderWidth = this.borderWidth;
     return Container(
       width: size,
       height: size,
@@ -137,7 +258,7 @@ class ActiveDotItem extends StatelessWidget {
         color: color,
         borderRadius: BorderRadius.circular(borderRadius),
         border: borderColor != null && borderWidth != null
-            ? Border.all(color: borderColor!, width: borderWidth!)
+            ? Border.all(color: borderColor, width: borderWidth)
             : null,
       ),
     );
@@ -163,11 +284,22 @@ class InactiveDotItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<DotIndicatorTheme>(context);
     final scaling = theme.scaling;
-    final size = this.size ?? (12 * scaling);
-    final borderRadius = this.borderRadius ?? theme.radiusMd;
-    final borderColor = this.borderColor ?? theme.colorScheme.secondary;
-    final borderWidth = this.borderWidth ?? (2 * scaling);
+    final size = styleValue(
+        widgetValue: this.size,
+        themeValue: compTheme?.size,
+        defaultValue: 12 * scaling);
+    final borderRadius = styleValue(
+        widgetValue: this.borderRadius,
+        themeValue: compTheme?.borderRadius,
+        defaultValue: theme.radiusMd);
+    final borderColor =
+        this.borderColor ?? compTheme?.inactiveBorderColor ?? theme.colorScheme.secondary;
+    final borderWidth =
+        this.borderWidth ?? compTheme?.inactiveBorderWidth ?? (2 * scaling);
+    final color =
+        this.color ?? compTheme?.inactiveColor;
     return Container(
       width: size,
       height: size,

--- a/lib/src/components/display/fade_scroll.dart
+++ b/lib/src/components/display/fade_scroll.dart
@@ -1,27 +1,86 @@
+import 'package:flutter/foundation.dart';
+
 import '../../../shadcn_flutter.dart';
 
+/// Theme configuration for [FadeScroll].
+class FadeScrollTheme {
+  /// The distance from the start before fading begins.
+  final double? startOffset;
+
+  /// The distance from the end before fading begins.
+  final double? endOffset;
+
+  /// The gradient colors used for the fade.
+  final List<Color>? gradient;
+
+  /// Creates a [FadeScrollTheme].
+  const FadeScrollTheme({
+    this.startOffset,
+    this.endOffset,
+    this.gradient,
+  });
+
+  /// Creates a copy of this theme but with the given fields replaced.
+  FadeScrollTheme copyWith({
+    ValueGetter<double?>? startOffset,
+    ValueGetter<double?>? endOffset,
+    ValueGetter<List<Color>?>? gradient,
+  }) {
+    return FadeScrollTheme(
+      startOffset: startOffset == null ? this.startOffset : startOffset(),
+      endOffset: endOffset == null ? this.endOffset : endOffset(),
+      gradient: gradient == null ? this.gradient : gradient(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FadeScrollTheme &&
+        other.startOffset == startOffset &&
+        other.endOffset == endOffset &&
+        listEquals(other.gradient, gradient);
+  }
+
+  @override
+  int get hashCode => Object.hash(startOffset, endOffset, gradient);
+}
+
 class FadeScroll extends StatelessWidget {
-  final double startOffset;
-  final double endOffset;
+  final double? startOffset;
+  final double? endOffset;
   final double startCrossOffset;
   final double endCrossOffset;
   final Widget child;
   final ScrollController controller;
-  final List<Color> gradient;
+  final List<Color>? gradient;
 
   const FadeScroll({
     super.key,
-    required this.startOffset,
-    required this.endOffset,
+    this.startOffset,
+    this.endOffset,
     required this.child,
     required this.controller,
-    required this.gradient,
+    this.gradient,
     this.startCrossOffset = 0,
     this.endCrossOffset = 0,
   });
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<FadeScrollTheme>(context);
+    final startOffset = styleValue(
+        widgetValue: this.startOffset,
+        themeValue: compTheme?.startOffset,
+        defaultValue: 0.0);
+    final endOffset = styleValue(
+        widgetValue: this.endOffset,
+        themeValue: compTheme?.endOffset,
+        defaultValue: 0.0);
+    final gradient = styleValue(
+        widgetValue: this.gradient,
+        themeValue: compTheme?.gradient,
+        defaultValue: const [Colors.white, Colors.transparent]);
     return ListenableBuilder(
       listenable: controller,
       child: child,

--- a/lib/src/components/display/linear_progress_indicator.dart
+++ b/lib/src/components/display/linear_progress_indicator.dart
@@ -2,6 +2,82 @@ import 'dart:ui' as ui;
 
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [LinearProgressIndicator].
+class LinearProgressIndicatorTheme {
+  /// Foreground color of the progress bar.
+  final Color? color;
+
+  /// Background color behind the progress bar.
+  final Color? backgroundColor;
+
+  /// Minimum height of the indicator.
+  final double? minHeight;
+
+  /// Border radius of the indicator container.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Whether to show sparks animation.
+  final bool? showSparks;
+
+  /// Whether to disable animation.
+  final bool? disableAnimation;
+
+  /// Creates a [LinearProgressIndicatorTheme].
+  const LinearProgressIndicatorTheme({
+    this.color,
+    this.backgroundColor,
+    this.minHeight,
+    this.borderRadius,
+    this.showSparks,
+    this.disableAnimation,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  LinearProgressIndicatorTheme copyWith({
+    ValueGetter<Color?>? color,
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<double?>? minHeight,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+    ValueGetter<bool?>? showSparks,
+    ValueGetter<bool?>? disableAnimation,
+  }) {
+    return LinearProgressIndicatorTheme(
+      color: color == null ? this.color : color(),
+      backgroundColor: backgroundColor == null
+          ? this.backgroundColor
+          : backgroundColor(),
+      minHeight: minHeight == null ? this.minHeight : minHeight(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+      showSparks: showSparks == null ? this.showSparks : showSparks(),
+      disableAnimation: disableAnimation == null
+          ? this.disableAnimation
+          : disableAnimation(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is LinearProgressIndicatorTheme &&
+        other.color == color &&
+        other.backgroundColor == backgroundColor &&
+        other.minHeight == minHeight &&
+        other.borderRadius == borderRadius &&
+        other.showSparks == showSparks &&
+        other.disableAnimation == disableAnimation;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    color,
+    backgroundColor,
+    minHeight,
+    borderRadius,
+    showSparks,
+    disableAnimation,
+  );
+}
+
 const int _kIndeterminateLinearDuration = 1800;
 
 class LinearProgressIndicator extends StatelessWidget {
@@ -31,8 +107,8 @@ class LinearProgressIndicator extends StatelessWidget {
   final double? minHeight;
   final Color? color;
   final BorderRadiusGeometry? borderRadius;
-  final bool showSparks;
-  final bool disableAnimation;
+  final bool? showSparks;
+  final bool? disableAnimation;
 
   const LinearProgressIndicator({
     super.key,
@@ -41,47 +117,80 @@ class LinearProgressIndicator extends StatelessWidget {
     this.minHeight,
     this.color,
     this.borderRadius,
-    this.showSparks = false,
-    this.disableAnimation = false,
+    this.showSparks,
+    this.disableAnimation,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final directionality = Directionality.of(context);
+    final compTheme = ComponentTheme.maybeOf<LinearProgressIndicatorTheme>(
+      context,
+    );
+    final colorValue = styleValue(
+      widgetValue: color,
+      themeValue: compTheme?.color,
+      defaultValue: theme.colorScheme.primary,
+    );
+    final backgroundColorValue = styleValue(
+      widgetValue: backgroundColor,
+      themeValue: compTheme?.backgroundColor,
+      defaultValue: colorValue.scaleAlpha(0.2),
+    );
+    final minHeightValue = styleValue(
+      widgetValue: minHeight,
+      themeValue: compTheme?.minHeight,
+      defaultValue: theme.scaling * 2,
+    );
+    final borderRadiusValue = styleValue(
+      widgetValue: borderRadius,
+      themeValue: compTheme?.borderRadius,
+      defaultValue: BorderRadius.zero,
+    );
+    final showSparksValue = styleValue(
+      widgetValue: showSparks,
+      themeValue: compTheme?.showSparks,
+      defaultValue: false,
+    );
+    final disableAnimationValue = styleValue(
+      widgetValue: disableAnimation,
+      themeValue: compTheme?.disableAnimation,
+      defaultValue: false,
+    );
     Widget childWidget;
     if (value != null) {
       childWidget = AnimatedValueBuilder(
-          value: _LinearProgressIndicatorProperties(
-            start: 0,
-            end: value!.clamp(0, 1),
-            color: color ?? theme.colorScheme.primary,
-            backgroundColor:
-                backgroundColor ?? theme.colorScheme.primary.scaleAlpha(0.2),
-            showSparks: showSparks,
-            sparksColor: color ?? theme.colorScheme.primary,
-            sparksRadius: theme.scaling * 16,
-            textDirection: directionality,
-          ),
-          duration: disableAnimation ? Duration.zero : kDefaultDuration,
-          lerp: _LinearProgressIndicatorProperties.lerp,
-          curve: Curves.easeInOut,
-          builder: (context, value, child) {
-            return CustomPaint(
-              painter: _LinearProgressIndicatorPainter(
-                start: 0,
-                end: value.end,
-                start2: value.start2,
-                end2: value.end2,
-                color: value.color,
-                backgroundColor: value.backgroundColor,
-                showSparks: value.showSparks,
-                sparksColor: value.sparksColor,
-                sparksRadius: value.sparksRadius,
-                textDirection: value.textDirection,
-              ),
-            );
-          });
+        value: _LinearProgressIndicatorProperties(
+          start: 0,
+          end: value!.clamp(0, 1),
+          color: colorValue,
+          backgroundColor: backgroundColorValue,
+          showSparks: showSparksValue,
+          sparksColor: colorValue,
+          sparksRadius: theme.scaling * 16,
+          textDirection: directionality,
+        ),
+        duration: disableAnimationValue ? Duration.zero : kDefaultDuration,
+        lerp: _LinearProgressIndicatorProperties.lerp,
+        curve: Curves.easeInOut,
+        builder: (context, value, child) {
+          return CustomPaint(
+            painter: _LinearProgressIndicatorPainter(
+              start: 0,
+              end: value.end,
+              start2: value.start2,
+              end2: value.end2,
+              color: value.color,
+              backgroundColor: value.backgroundColor,
+              showSparks: value.showSparks,
+              sparksColor: value.sparksColor,
+              sparksRadius: value.sparksRadius,
+              textDirection: value.textDirection,
+            ),
+          );
+        },
+      );
     } else {
       // indeterminate
       childWidget = RepeatedAnimationBuilder(
@@ -94,48 +203,45 @@ class LinearProgressIndicator extends StatelessWidget {
           double start2 = _line2Tail.transform(value);
           double end2 = _line2Head.transform(value);
           return AnimatedValueBuilder(
-              duration: kDefaultDuration,
-              lerp: _LinearProgressIndicatorProperties.lerp,
-              value: _LinearProgressIndicatorProperties(
-                start: start,
-                end: end,
-                start2: start2,
-                end2: end2,
-                color: color ?? theme.colorScheme.primary,
-                backgroundColor: backgroundColor ??
-                    theme.colorScheme.primary.scaleAlpha(0.2),
-                showSparks: showSparks,
-                sparksColor: color ?? theme.colorScheme.primary,
-                sparksRadius: theme.scaling * 16,
-                textDirection: directionality,
-              ),
-              builder: (context, prop, child) {
-                return CustomPaint(
-                  painter: _LinearProgressIndicatorPainter(
-                    // do not animate start and end value
-                    start: start,
-                    end: end,
-                    start2: start2,
-                    end2: end2,
-                    color: prop.color,
-                    backgroundColor: prop.backgroundColor,
-                    showSparks: prop.showSparks,
-                    sparksColor: prop.sparksColor,
-                    sparksRadius: prop.sparksRadius,
-                    textDirection: prop.textDirection,
-                  ),
-                );
-              });
+            duration: kDefaultDuration,
+            lerp: _LinearProgressIndicatorProperties.lerp,
+            value: _LinearProgressIndicatorProperties(
+              start: start,
+              end: end,
+              start2: start2,
+              end2: end2,
+              color: colorValue,
+              backgroundColor: backgroundColorValue,
+              showSparks: showSparksValue,
+              sparksColor: colorValue,
+              sparksRadius: theme.scaling * 16,
+              textDirection: directionality,
+            ),
+            builder: (context, prop, child) {
+              return CustomPaint(
+                painter: _LinearProgressIndicatorPainter(
+                  // do not animate start and end value
+                  start: start,
+                  end: end,
+                  start2: start2,
+                  end2: end2,
+                  color: prop.color,
+                  backgroundColor: prop.backgroundColor,
+                  showSparks: prop.showSparks,
+                  sparksColor: prop.sparksColor,
+                  sparksRadius: prop.sparksRadius,
+                  textDirection: prop.textDirection,
+                ),
+              );
+            },
+          );
         },
       );
     }
     return RepaintBoundary(
       child: SizedBox(
-        height: minHeight ?? (theme.scaling * 2),
-        child: ClipRRect(
-          borderRadius: borderRadius ?? BorderRadius.zero,
-          child: childWidget,
-        ),
+        height: minHeightValue,
+        child: ClipRRect(borderRadius: borderRadiusValue, child: childWidget),
       ),
     );
   }
@@ -258,7 +364,12 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 
     canvas.drawRRect(
       RRect.fromLTRBR(
-          0, 0, size.width, size.height, Radius.circular(size.height / 2)),
+        0,
+        0,
+        size.width,
+        size.height,
+        Radius.circular(size.height / 2),
+      ),
       paint,
     );
 
@@ -288,10 +399,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
         // stops: const [0.0, 1.0],
         Offset(size.width * (end - start), size.height / 2),
         sparksRadius,
-        [
-          sparksColor,
-          sparksColor.withAlpha(0),
-        ],
+        [sparksColor, sparksColor.withAlpha(0)],
         [0.0, 1.0],
         ui.TileMode.clamp,
         // scale to make oval

--- a/lib/src/components/display/number_ticker.dart
+++ b/lib/src/components/display/number_ticker.dart
@@ -4,14 +4,54 @@ typedef NumberTickerBuilder = Widget Function(
     BuildContext context, num number, Widget? child);
 typedef NumberTickerFormatted = String Function(num number);
 
+/// Theme for [NumberTicker].
+class NumberTickerTheme {
+  /// The animation duration.
+  final Duration? duration;
+
+  /// The animation curve.
+  final Curve? curve;
+
+  /// The text style when [formatter] is used.
+  final TextStyle? style;
+
+  /// Creates a [NumberTickerTheme].
+  const NumberTickerTheme({this.duration, this.curve, this.style});
+
+  /// Creates a copy of this theme with the given values replaced.
+  NumberTickerTheme copyWith({
+    ValueGetter<Duration?>? duration,
+    ValueGetter<Curve?>? curve,
+    ValueGetter<TextStyle?>? style,
+  }) {
+    return NumberTickerTheme(
+      duration: duration == null ? this.duration : duration(),
+      curve: curve == null ? this.curve : curve(),
+      style: style == null ? this.style : style(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NumberTickerTheme &&
+        other.duration == duration &&
+        other.curve == curve &&
+        other.style == style;
+  }
+
+  @override
+  int get hashCode => Object.hash(duration, curve, style);
+}
+
 class NumberTicker extends StatelessWidget {
   final num? initialNumber;
   final num number;
   final NumberTickerBuilder? builder;
   final Widget? child;
   final NumberTickerFormatted? formatter;
-  final Duration duration;
-  final Curve curve;
+  final Duration? duration;
+  final Curve? curve;
   final TextStyle? style;
 
   const NumberTicker.builder({
@@ -20,8 +60,8 @@ class NumberTicker extends StatelessWidget {
     required this.number,
     required this.builder,
     this.child,
-    this.duration = const Duration(milliseconds: 500),
-    this.curve = Curves.easeInOut,
+    this.duration,
+    this.curve,
   })  : formatter = null,
         style = null;
 
@@ -30,15 +70,31 @@ class NumberTicker extends StatelessWidget {
     this.initialNumber,
     required this.number,
     required this.formatter,
-    this.duration = const Duration(milliseconds: 500),
-    this.curve = Curves.easeInOut,
+    this.duration,
+    this.curve,
     this.style,
   })  : builder = null,
         child = null;
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<NumberTickerTheme>(context);
+    final duration = styleValue(
+      widgetValue: this.duration,
+      themeValue: compTheme?.duration,
+      defaultValue: const Duration(milliseconds: 500),
+    );
+    final curve = styleValue(
+      widgetValue: this.curve,
+      themeValue: compTheme?.curve,
+      defaultValue: Curves.easeInOut,
+    );
     if (formatter != null) {
+      final textStyle = styleValue(
+        widgetValue: style,
+        themeValue: compTheme?.style,
+        defaultValue: null,
+      );
       return AnimatedValueBuilder(
         value: number.toDouble(),
         duration: duration,
@@ -47,7 +103,7 @@ class NumberTicker extends StatelessWidget {
         builder: (context, value, child) {
           return Text(
             formatter!(value),
-            style: style,
+            style: textStyle,
           );
         },
       );

--- a/lib/src/components/display/skeleton.dart
+++ b/lib/src/components/display/skeleton.dart
@@ -1,78 +1,144 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
+/// Theme for skeleton loading configuration.
+class SkeletonTheme {
+  /// Duration of the pulse effect.
+  final Duration? duration;
+
+  /// Starting color of the pulse effect.
+  final Color? fromColor;
+
+  /// Ending color of the pulse effect.
+  final Color? toColor;
+
+  /// Whether switching animation is enabled.
+  final bool? enableSwitchAnimation;
+
+  /// Creates a [SkeletonTheme].
+  const SkeletonTheme({
+    this.duration,
+    this.fromColor,
+    this.toColor,
+    this.enableSwitchAnimation,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  SkeletonTheme copyWith({
+    ValueGetter<Duration?>? duration,
+    ValueGetter<Color?>? fromColor,
+    ValueGetter<Color?>? toColor,
+    ValueGetter<bool?>? enableSwitchAnimation,
+  }) {
+    return SkeletonTheme(
+      duration: duration == null ? this.duration : duration(),
+      fromColor: fromColor == null ? this.fromColor : fromColor(),
+      toColor: toColor == null ? this.toColor : toColor(),
+      enableSwitchAnimation: enableSwitchAnimation == null
+          ? this.enableSwitchAnimation
+          : enableSwitchAnimation(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SkeletonTheme &&
+        other.duration == duration &&
+        other.fromColor == fromColor &&
+        other.toColor == toColor &&
+        other.enableSwitchAnimation == enableSwitchAnimation;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(duration, fromColor, toColor, enableSwitchAnimation);
+}
+
 class ShadcnSkeletonizerConfigLayer extends StatelessWidget {
   final ThemeData theme;
   final Widget child;
+  final Duration? duration;
+  final Color? fromColor;
+  final Color? toColor;
+  final bool? enableSwitchAnimation;
 
   const ShadcnSkeletonizerConfigLayer({
     super.key,
     required this.theme,
     required this.child,
+    this.duration,
+    this.fromColor,
+    this.toColor,
+    this.enableSwitchAnimation,
   });
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<SkeletonTheme>(context);
+    final durationValue = styleValue(
+      widgetValue: duration,
+      themeValue: compTheme?.duration,
+      defaultValue: const Duration(seconds: 1),
+    );
+    final fromValue = styleValue(
+      widgetValue: fromColor,
+      themeValue: compTheme?.fromColor,
+      defaultValue: theme.colorScheme.primary.scaleAlpha(0.05),
+    );
+    final toValue = styleValue(
+      widgetValue: toColor,
+      themeValue: compTheme?.toColor,
+      defaultValue: theme.colorScheme.primary.scaleAlpha(0.1),
+    );
+    final enableSwitchAnimationValue = styleValue(
+      widgetValue: enableSwitchAnimation,
+      themeValue: compTheme?.enableSwitchAnimation,
+      defaultValue: true,
+    );
     return SkeletonizerConfig(
-        data: SkeletonizerConfigData(
-          effect: PulseEffect(
-            duration: const Duration(seconds: 1),
-            from: theme.colorScheme.primary.scaleAlpha(0.05),
-            to: theme.colorScheme.primary.scaleAlpha(0.1),
-          ),
-          enableSwitchAnimation: true,
+      data: SkeletonizerConfigData(
+        effect: PulseEffect(
+          duration: durationValue,
+          from: fromValue,
+          to: toValue,
         ),
-        child: child);
+        enableSwitchAnimation: enableSwitchAnimationValue,
+      ),
+      child: child,
+    );
   }
 }
 
 extension SkeletonExtension on Widget {
   Widget asSkeletonSliver({bool enabled = true}) {
-    return Skeletonizer(
-      enabled: enabled,
-      ignoreContainers: false,
-      child: this,
-    );
+    return Skeletonizer(enabled: enabled, ignoreContainers: false, child: this);
   }
 
-  Widget asSkeleton(
-      {bool enabled = true,
-      bool leaf = false,
-      Widget? replacement,
-      bool unite = false,
-      AsyncSnapshot? snapshot}) {
+  Widget asSkeleton({
+    bool enabled = true,
+    bool leaf = false,
+    Widget? replacement,
+    bool unite = false,
+    AsyncSnapshot? snapshot,
+  }) {
     if (snapshot != null) {
       enabled = !snapshot.hasData;
     }
     if (this is Avatar || this is Image) {
       // https://github.com/Milad-Akarie/skeletonizer/issues/17
-      return Skeleton.leaf(
-        enabled: enabled,
-        child: this,
-      );
+      return Skeleton.leaf(enabled: enabled, child: this);
     }
     if (unite) {
-      return Skeleton.unite(
-        unite: enabled,
-        child: this,
-      );
+      return Skeleton.unite(unite: enabled, child: this);
     }
     if (replacement != null) {
-      return Skeleton.replace(
-        replace: enabled,
-        child: replacement,
-      );
+      return Skeleton.replace(replace: enabled, child: replacement);
     }
     if (leaf) {
-      return Skeleton.leaf(
-        enabled: enabled,
-        child: this,
-      );
+      return Skeleton.leaf(enabled: enabled, child: this);
     }
-    return Skeletonizer(
-      enabled: enabled,
-      child: this,
-    );
+    return Skeletonizer(enabled: enabled, child: this);
   }
 
   Widget ignoreSkeleton() {
@@ -80,9 +146,6 @@ extension SkeletonExtension on Widget {
   }
 
   Widget excludeSkeleton({bool exclude = true}) {
-    return Skeleton.keep(
-      keep: exclude,
-      child: this,
-    );
+    return Skeleton.keep(keep: exclude, child: this);
   }
 }

--- a/lib/src/components/form/switch.dart
+++ b/lib/src/components/form/switch.dart
@@ -5,6 +5,72 @@ import '../../../shadcn_flutter.dart';
 
 const kSwitchDuration = Duration(milliseconds: 100);
 
+/// A theme for [Switch] widgets.
+class SwitchTheme {
+  /// The color of the track when the switch is on.
+  final Color? activeColor;
+
+  /// The color of the track when the switch is off.
+  final Color? inactiveColor;
+
+  /// The color of the thumb.
+  final Color? thumbColor;
+
+  /// The gap between the switch and its leading/trailing widgets.
+  final double? gap;
+
+  /// The border radius of the track.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Creates a [SwitchTheme].
+  const SwitchTheme({
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor,
+    this.gap,
+    this.borderRadius,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  SwitchTheme copyWith({
+    ValueGetter<Color?>? activeColor,
+    ValueGetter<Color?>? inactiveColor,
+    ValueGetter<Color?>? thumbColor,
+    ValueGetter<double?>? gap,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+  }) {
+    return SwitchTheme(
+      activeColor: activeColor == null ? this.activeColor : activeColor(),
+      inactiveColor:
+          inactiveColor == null ? this.inactiveColor : inactiveColor(),
+      thumbColor: thumbColor == null ? this.thumbColor : thumbColor(),
+      gap: gap == null ? this.gap : gap(),
+      borderRadius:
+          borderRadius == null ? this.borderRadius : borderRadius(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SwitchTheme &&
+        other.activeColor == activeColor &&
+        other.inactiveColor == inactiveColor &&
+        other.thumbColor == thumbColor &&
+        other.gap == gap &&
+        other.borderRadius == borderRadius;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        activeColor,
+        inactiveColor,
+        thumbColor,
+        gap,
+        borderRadius,
+      );
+}
+
 class SwitchController extends ValueNotifier<bool>
     with ComponentController<bool> {
   SwitchController([super.value = false]);
@@ -26,6 +92,11 @@ class ControlledSwitch extends StatelessWidget with ControlledComponent<bool> {
 
   final Widget? leading;
   final Widget? trailing;
+  final double? gap;
+  final Color? activeColor;
+  final Color? inactiveColor;
+  final Color? thumbColor;
+  final BorderRadiusGeometry? borderRadius;
 
   const ControlledSwitch({
     super.key,
@@ -35,6 +106,11 @@ class ControlledSwitch extends StatelessWidget with ControlledComponent<bool> {
     this.enabled = true,
     this.leading,
     this.trailing,
+    this.gap,
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor,
+    this.borderRadius,
   });
 
   @override
@@ -51,6 +127,11 @@ class ControlledSwitch extends StatelessWidget with ControlledComponent<bool> {
           enabled: data.enabled,
           leading: leading,
           trailing: trailing,
+          gap: gap,
+          activeColor: activeColor,
+          inactiveColor: inactiveColor,
+          thumbColor: thumbColor,
+          borderRadius: borderRadius,
         );
       },
     );
@@ -63,6 +144,11 @@ class Switch extends StatefulWidget {
   final Widget? leading;
   final Widget? trailing;
   final bool? enabled;
+  final double? gap;
+  final Color? activeColor;
+  final Color? inactiveColor;
+  final Color? thumbColor;
+  final BorderRadiusGeometry? borderRadius;
 
   const Switch({
     super.key,
@@ -71,6 +157,11 @@ class Switch extends StatefulWidget {
     this.leading,
     this.trailing,
     this.enabled = true,
+    this.gap,
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor,
+    this.borderRadius,
   });
 
   @override
@@ -105,9 +196,32 @@ class _SwitchState extends State<Switch> with FormValueSupplier<bool, Switch> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<SwitchTheme>(context);
+    final gap = styleValue(
+        widgetValue: widget.gap,
+        themeValue: compTheme?.gap,
+        defaultValue: 8 * scaling);
+    final activeColor = styleValue(
+        widgetValue: widget.activeColor,
+        themeValue: compTheme?.activeColor,
+        defaultValue: theme.colorScheme.primary);
+    final inactiveColor = styleValue(
+        widgetValue: widget.inactiveColor,
+        themeValue: compTheme?.inactiveColor,
+        defaultValue: theme.colorScheme.border);
+    final thumbColor = styleValue(
+        widgetValue: widget.thumbColor,
+        themeValue: compTheme?.thumbColor,
+        defaultValue: theme.colorScheme.background);
+    final borderRadius = styleValue<BorderRadiusGeometry>(
+        widgetValue: widget.borderRadius,
+        themeValue: compTheme?.borderRadius,
+        defaultValue: BorderRadius.circular(theme.radiusXl));
     return FocusOutline(
       focused: _focusing,
-      borderRadius: BorderRadius.circular(theme.radiusXl),
+      borderRadius:
+          optionallyResolveBorderRadius(context, borderRadius) ??
+              BorderRadius.circular(theme.radiusXl),
       align: 3 * scaling,
       width: 2 * scaling,
       child: GestureDetector(
@@ -138,24 +252,26 @@ class _SwitchState extends State<Switch> with FormValueSupplier<bool, Switch> {
           mouseCursor: _enabled
               ? SystemMouseCursors.click
               : SystemMouseCursors.forbidden,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisSize: MainAxisSize.min,
-            children: [
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
               if (widget.leading != null) widget.leading!,
-              if (widget.leading != null) SizedBox(width: 8 * scaling),
+              if (widget.leading != null) SizedBox(width: gap),
               AnimatedContainer(
                 duration: kSwitchDuration,
                 width: (32 + 4) * scaling,
                 height: (16 + 4) * scaling,
                 padding: EdgeInsets.all(2 * scaling),
                 decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(theme.radiusXl),
+                  borderRadius:
+                      optionallyResolveBorderRadius(context, borderRadius) ??
+                          BorderRadius.circular(theme.radiusXl),
                   color: !_enabled
                       ? theme.colorScheme.muted
                       : widget.value
-                          ? theme.colorScheme.primary
-                          : theme.colorScheme.border,
+                          ? activeColor
+                          : inactiveColor,
                 ),
                 child: Stack(
                   children: [
@@ -170,7 +286,7 @@ class _SwitchState extends State<Switch> with FormValueSupplier<bool, Switch> {
                         child: Container(
                           decoration: BoxDecoration(
                             borderRadius: BorderRadius.circular(theme.radiusLg),
-                            color: theme.colorScheme.background,
+                            color: thumbColor,
                           ),
                         ),
                       ),
@@ -178,7 +294,7 @@ class _SwitchState extends State<Switch> with FormValueSupplier<bool, Switch> {
                   ],
                 ),
               ),
-              if (widget.trailing != null) SizedBox(width: 8 * scaling),
+              if (widget.trailing != null) SizedBox(width: gap),
               if (widget.trailing != null) widget.trailing!,
             ],
           ),

--- a/lib/src/components/layout/alert.dart
+++ b/lib/src/components/layout/alert.dart
@@ -1,5 +1,46 @@
 import '../../../shadcn_flutter.dart';
 
+/// Theme for [Alert].
+class AlertTheme {
+  /// The padding around the alert content.
+  final EdgeInsetsGeometry? padding;
+
+  /// The background color of the alert.
+  final Color? backgroundColor;
+
+  /// The border color of the alert.
+  final Color? borderColor;
+
+  /// Creates an [AlertTheme].
+  const AlertTheme({this.padding, this.backgroundColor, this.borderColor});
+
+  /// Creates a copy of this theme with the given values replaced.
+  AlertTheme copyWith({
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<Color?>? borderColor,
+  }) {
+    return AlertTheme(
+      padding: padding == null ? this.padding : padding(),
+      backgroundColor:
+          backgroundColor == null ? this.backgroundColor : backgroundColor(),
+      borderColor: borderColor == null ? this.borderColor : borderColor(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AlertTheme &&
+        other.padding == padding &&
+        other.backgroundColor == backgroundColor &&
+        other.borderColor == borderColor;
+  }
+
+  @override
+  int get hashCode => Object.hash(padding, backgroundColor, borderColor);
+}
+
 class Alert extends StatelessWidget {
   final Widget? leading;
   final Widget? title;
@@ -44,15 +85,29 @@ class Alert extends StatelessWidget {
 
   Widget _build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<AlertTheme>(context);
     final scaling = theme.scaling;
     var scheme = theme.colorScheme;
+    final padding = styleValue(
+      themeValue: compTheme?.padding,
+      defaultValue:
+          EdgeInsets.symmetric(horizontal: 16 * scaling, vertical: 12 * scaling),
+    );
+    final backgroundColor = styleValue(
+      themeValue: compTheme?.backgroundColor,
+      defaultValue: scheme.background,
+    );
+    final borderColor = styleValue(
+      widgetValue: destructive ? scheme.destructive : null,
+      themeValue: compTheme?.borderColor,
+      defaultValue: destructive ? scheme.destructive : null,
+    );
 
     return OutlinedContainer(
-      backgroundColor: scheme.background,
-      borderColor: destructive ? scheme.destructive : null,
+      backgroundColor: backgroundColor,
+      borderColor: borderColor,
       child: Container(
-        padding: EdgeInsets.symmetric(
-            horizontal: 16 * scaling, vertical: 12 * scaling),
+        padding: padding,
         child: Basic(
           leading: leading,
           title: title,

--- a/lib/src/components/layout/basic.dart
+++ b/lib/src/components/layout/basic.dart
@@ -1,5 +1,90 @@
 import '../../../shadcn_flutter.dart';
 
+class BasicTheme {
+  final AlignmentGeometry? leadingAlignment;
+  final AlignmentGeometry? trailingAlignment;
+  final AlignmentGeometry? titleAlignment;
+  final AlignmentGeometry? subtitleAlignment;
+  final AlignmentGeometry? contentAlignment;
+  final double? contentSpacing;
+  final double? titleSpacing;
+  final MainAxisAlignment? mainAxisAlignment;
+  final EdgeInsetsGeometry? padding;
+
+  const BasicTheme({
+    this.leadingAlignment,
+    this.trailingAlignment,
+    this.titleAlignment,
+    this.subtitleAlignment,
+    this.contentAlignment,
+    this.contentSpacing,
+    this.titleSpacing,
+    this.mainAxisAlignment,
+    this.padding,
+  });
+
+  BasicTheme copyWith({
+    ValueGetter<AlignmentGeometry?>? leadingAlignment,
+    ValueGetter<AlignmentGeometry?>? trailingAlignment,
+    ValueGetter<AlignmentGeometry?>? titleAlignment,
+    ValueGetter<AlignmentGeometry?>? subtitleAlignment,
+    ValueGetter<AlignmentGeometry?>? contentAlignment,
+    ValueGetter<double?>? contentSpacing,
+    ValueGetter<double?>? titleSpacing,
+    ValueGetter<MainAxisAlignment?>? mainAxisAlignment,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+  }) {
+    return BasicTheme(
+      leadingAlignment:
+          leadingAlignment == null ? this.leadingAlignment : leadingAlignment(),
+      trailingAlignment:
+          trailingAlignment == null ? this.trailingAlignment : trailingAlignment(),
+      titleAlignment:
+          titleAlignment == null ? this.titleAlignment : titleAlignment(),
+      subtitleAlignment: subtitleAlignment == null
+          ? this.subtitleAlignment
+          : subtitleAlignment(),
+      contentAlignment: contentAlignment == null
+          ? this.contentAlignment
+          : contentAlignment(),
+      contentSpacing:
+          contentSpacing == null ? this.contentSpacing : contentSpacing(),
+      titleSpacing: titleSpacing == null ? this.titleSpacing : titleSpacing(),
+      mainAxisAlignment: mainAxisAlignment == null
+          ? this.mainAxisAlignment
+          : mainAxisAlignment(),
+      padding: padding == null ? this.padding : padding(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BasicTheme &&
+        other.leadingAlignment == leadingAlignment &&
+        other.trailingAlignment == trailingAlignment &&
+        other.titleAlignment == titleAlignment &&
+        other.subtitleAlignment == subtitleAlignment &&
+        other.contentAlignment == contentAlignment &&
+        other.contentSpacing == contentSpacing &&
+        other.titleSpacing == titleSpacing &&
+        other.mainAxisAlignment == mainAxisAlignment &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        leadingAlignment,
+        trailingAlignment,
+        titleAlignment,
+        subtitleAlignment,
+        contentAlignment,
+        contentSpacing,
+        titleSpacing,
+        mainAxisAlignment,
+        padding,
+      );
+}
+
 class Basic extends StatelessWidget {
   final Widget? leading;
   final Widget? title;
@@ -13,7 +98,7 @@ class Basic extends StatelessWidget {
   final AlignmentGeometry? contentAlignment;
   final double? contentSpacing;
   final double? titleSpacing;
-  final MainAxisAlignment mainAxisAlignment;
+  final MainAxisAlignment? mainAxisAlignment;
   final EdgeInsetsGeometry? padding;
 
   const Basic({
@@ -30,7 +115,7 @@ class Basic extends StatelessWidget {
     this.contentAlignment,
     this.contentSpacing, // 16
     this.titleSpacing, //4
-    this.mainAxisAlignment = MainAxisAlignment.center,
+    this.mainAxisAlignment,
     this.padding,
   });
 
@@ -38,22 +123,59 @@ class Basic extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<BasicTheme>(context);
+    final padding = styleValue(
+        widgetValue: this.padding,
+        themeValue: compTheme?.padding,
+        defaultValue: EdgeInsets.zero);
+    final contentSpacing = styleValue(
+        widgetValue: this.contentSpacing,
+        themeValue: compTheme?.contentSpacing,
+        defaultValue: 16 * scaling);
+    final titleSpacing = styleValue(
+        widgetValue: this.titleSpacing,
+        themeValue: compTheme?.titleSpacing,
+        defaultValue: 4 * scaling);
+    final leadingAlignment = styleValue(
+        widgetValue: this.leadingAlignment,
+        themeValue: compTheme?.leadingAlignment,
+        defaultValue: Alignment.topCenter);
+    final trailingAlignment = styleValue(
+        widgetValue: this.trailingAlignment,
+        themeValue: compTheme?.trailingAlignment,
+        defaultValue: Alignment.topCenter);
+    final titleAlignment = styleValue(
+        widgetValue: this.titleAlignment,
+        themeValue: compTheme?.titleAlignment,
+        defaultValue: Alignment.topLeft);
+    final subtitleAlignment = styleValue(
+        widgetValue: this.subtitleAlignment,
+        themeValue: compTheme?.subtitleAlignment,
+        defaultValue: Alignment.topLeft);
+    final contentAlignment = styleValue(
+        widgetValue: this.contentAlignment,
+        themeValue: compTheme?.contentAlignment,
+        defaultValue: Alignment.topLeft);
+    final mainAxisAlignment = styleValue(
+        widgetValue: this.mainAxisAlignment,
+        themeValue: compTheme?.mainAxisAlignment,
+        defaultValue: MainAxisAlignment.center);
     return Padding(
-      padding: padding ?? EdgeInsets.zero,
+      padding: padding,
       child: IntrinsicWidth(
         child: IntrinsicHeight(
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisAlignment: mainAxisAlignment,
             children: [
               if (leading != null)
                 Align(
-                  alignment: leadingAlignment ?? Alignment.topCenter,
+                  alignment: leadingAlignment,
                   child: leading!,
                 ),
               if (leading != null &&
                   (title != null || content != null || subtitle != null))
-                SizedBox(width: contentSpacing ?? (16 * scaling)),
+                SizedBox(width: contentSpacing),
               if (title != null || content != null || subtitle != null)
                 Expanded(
                   child: Column(
@@ -62,14 +184,14 @@ class Basic extends StatelessWidget {
                     children: [
                       if (title != null)
                         Align(
-                          alignment: titleAlignment ?? Alignment.topLeft,
+                          alignment: titleAlignment,
                           child: title!,
                         ).small().medium(),
                       if (title != null && subtitle != null)
                         SizedBox(height: 2 * scaling),
                       if (subtitle != null)
                         Align(
-                          alignment: subtitleAlignment ?? Alignment.topLeft,
+                          alignment: subtitleAlignment,
                           child: subtitle!,
                         ).xSmall().muted(),
                       if ((title != null || subtitle != null) &&
@@ -77,7 +199,7 @@ class Basic extends StatelessWidget {
                         SizedBox(height: titleSpacing),
                       if (content != null)
                         Align(
-                          alignment: contentAlignment ?? Alignment.topLeft,
+                          alignment: contentAlignment,
                           child: content!,
                         ).small(),
                     ],
@@ -88,11 +210,11 @@ class Basic extends StatelessWidget {
                       content != null ||
                       leading != null ||
                       subtitle != null))
-                SizedBox(width: contentSpacing ?? (16 * scaling)),
+                SizedBox(width: contentSpacing),
               // if (trailing != null) trailing!,
               if (trailing != null)
                 Align(
-                  alignment: trailingAlignment ?? Alignment.topCenter,
+                  alignment: trailingAlignment,
                   child: trailing!,
                 ),
             ],
@@ -140,17 +262,46 @@ class BasicLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<BasicTheme>(context);
+    final contentSpacing = styleValue(
+        widgetValue: this.contentSpacing,
+        themeValue: compTheme?.contentSpacing,
+        defaultValue: 16 * scaling);
+    final titleSpacing = styleValue(
+        widgetValue: this.titleSpacing,
+        themeValue: compTheme?.titleSpacing,
+        defaultValue: 4 * scaling);
+    final leadingAlignment = styleValue(
+        widgetValue: this.leadingAlignment,
+        themeValue: compTheme?.leadingAlignment,
+        defaultValue: Alignment.topCenter);
+    final trailingAlignment = styleValue(
+        widgetValue: this.trailingAlignment,
+        themeValue: compTheme?.trailingAlignment,
+        defaultValue: Alignment.topCenter);
+    final titleAlignment = styleValue(
+        widgetValue: this.titleAlignment,
+        themeValue: compTheme?.titleAlignment,
+        defaultValue: Alignment.topLeft);
+    final subtitleAlignment = styleValue(
+        widgetValue: this.subtitleAlignment,
+        themeValue: compTheme?.subtitleAlignment,
+        defaultValue: Alignment.topLeft);
+    final contentAlignment = styleValue(
+        widgetValue: this.contentAlignment,
+        themeValue: compTheme?.contentAlignment,
+        defaultValue: Alignment.topLeft);
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         if (leading != null)
           Align(
-            alignment: leadingAlignment ?? Alignment.topCenter,
+            alignment: leadingAlignment,
             child: leading!,
           ),
         if (leading != null &&
             (title != null || content != null || subtitle != null))
-          SizedBox(width: contentSpacing ?? (16 * scaling)),
+          SizedBox(width: contentSpacing),
         if (title != null || content != null || subtitle != null)
           Expanded(
             child: Column(
@@ -160,21 +311,21 @@ class BasicLayout extends StatelessWidget {
               children: [
                 if (title != null)
                   Align(
-                    alignment: titleAlignment ?? Alignment.topLeft,
+                    alignment: titleAlignment,
                     child: title!,
                   ),
                 if (title != null && subtitle != null)
                   SizedBox(height: 2 * scaling),
                 if (subtitle != null)
                   Align(
-                    alignment: subtitleAlignment ?? Alignment.topLeft,
+                    alignment: subtitleAlignment,
                     child: subtitle!,
                   ),
                 if ((title != null || subtitle != null) && content != null)
-                  SizedBox(height: titleSpacing ?? (4 * scaling)),
+                  SizedBox(height: titleSpacing),
                 if (content != null)
                   Align(
-                    alignment: contentAlignment ?? Alignment.topLeft,
+                    alignment: contentAlignment,
                     child: content!,
                   ),
               ],
@@ -185,10 +336,10 @@ class BasicLayout extends StatelessWidget {
                 content != null ||
                 leading != null ||
                 subtitle != null))
-          SizedBox(width: contentSpacing ?? (16 * scaling)),
+          SizedBox(width: contentSpacing),
         if (trailing != null)
           Align(
-            alignment: trailingAlignment ?? Alignment.topCenter,
+            alignment: trailingAlignment,
             child: trailing!,
           ),
       ],

--- a/lib/src/components/layout/breadcrumb.dart
+++ b/lib/src/components/layout/breadcrumb.dart
@@ -2,6 +2,40 @@ import 'package:flutter/gestures.dart';
 
 import '../../../shadcn_flutter.dart';
 
+/// Theme for [Breadcrumb].
+class BreadcrumbTheme {
+  /// Separator widget between breadcrumb items.
+  final Widget? separator;
+
+  /// Padding around the breadcrumb row.
+  final EdgeInsetsGeometry? padding;
+
+  /// Creates a [BreadcrumbTheme].
+  const BreadcrumbTheme({this.separator, this.padding});
+
+  /// Returns a copy of this theme with the given fields replaced.
+  BreadcrumbTheme copyWith({
+    ValueGetter<Widget?>? separator,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+  }) {
+    return BreadcrumbTheme(
+      separator: separator == null ? this.separator : separator(),
+      padding: padding == null ? this.padding : padding(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is BreadcrumbTheme &&
+        other.separator == separator &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(separator, padding);
+}
+
 class _ArrowSeparator extends StatelessWidget {
   const _ArrowSeparator();
 
@@ -11,9 +45,7 @@ class _ArrowSeparator extends StatelessWidget {
     final scaling = theme.scaling;
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 12 * scaling),
-      child: const Icon(
-        RadixIcons.chevronRight,
-      ).iconXSmall().muted(),
+      child: const Icon(RadixIcons.chevronRight).iconXSmall().muted(),
     );
   }
 }
@@ -36,37 +68,45 @@ class Breadcrumb extends StatelessWidget {
   static const Widget arrowSeparator = _ArrowSeparator();
   static const Widget slashSeparator = _SlashSeparator();
   final List<Widget> children;
-  final Widget separator;
+  final Widget? separator;
+  final EdgeInsetsGeometry? padding;
 
   const Breadcrumb({
     super.key,
     required this.children,
-    required this.separator,
+    this.separator,
+    this.padding,
   });
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<BreadcrumbTheme>(context);
+    final sep = separator ?? compTheme?.separator ?? Breadcrumb.arrowSeparator;
+    final pad = styleValue(
+      widgetValue: padding,
+      themeValue: compTheme?.padding,
+      defaultValue: EdgeInsets.zero,
+    );
     return ScrollConfiguration(
-      behavior: ScrollConfiguration.of(context)
-          .copyWith(scrollbars: false, dragDevices: {PointerDeviceKind.touch}),
+      behavior: ScrollConfiguration.of(
+        context,
+      ).copyWith(scrollbars: false, dragDevices: {PointerDeviceKind.touch}),
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
-        child: Row(
-          children: [
-            if (children.length == 1) children[0].medium().foreground(),
-            if (children.length > 1)
-              for (var i = 0; i < children.length; i++)
-                if (i == children.length - 1)
-                  children[i].medium().foreground()
-                else
-                  Row(
-                    children: [
-                      children[i].medium(),
-                      separator,
-                    ],
-                  ),
-          ],
-        ).small().muted(),
+        child: Padding(
+          padding: pad,
+          child: Row(
+            children: [
+              if (children.length == 1) children[0].medium().foreground(),
+              if (children.length > 1)
+                for (var i = 0; i < children.length; i++)
+                  if (i == children.length - 1)
+                    children[i].medium().foreground()
+                  else
+                    Row(children: [children[i].medium(), sep]),
+            ],
+          ).small().muted(),
+        ),
       ),
     );
   }

--- a/lib/src/components/layout/card.dart
+++ b/lib/src/components/layout/card.dart
@@ -1,14 +1,127 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [Card] and [SurfaceCard].
+class CardTheme {
+  /// Padding inside the card.
+  final EdgeInsetsGeometry? padding;
+
+  /// Whether the card is filled.
+  final bool? filled;
+
+  /// The fill color when [filled] is true.
+  final Color? fillColor;
+
+  /// Border radius of the card.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Border color of the card.
+  final Color? borderColor;
+
+  /// Border width of the card.
+  final double? borderWidth;
+
+  /// Clip behavior of the card.
+  final Clip? clipBehavior;
+
+  /// Box shadow of the card.
+  final List<BoxShadow>? boxShadow;
+
+  /// Surface opacity for blurred background.
+  final double? surfaceOpacity;
+
+  /// Surface blur for blurred background.
+  final double? surfaceBlur;
+
+  /// Animation duration for transitions.
+  final Duration? duration;
+
+  /// Creates a [CardTheme].
+  const CardTheme({
+    this.padding,
+    this.filled,
+    this.fillColor,
+    this.borderRadius,
+    this.borderColor,
+    this.borderWidth,
+    this.clipBehavior,
+    this.boxShadow,
+    this.surfaceOpacity,
+    this.surfaceBlur,
+    this.duration,
+  });
+
+  /// Creates a copy of this theme with the given values replaced.
+  CardTheme copyWith({
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<bool?>? filled,
+    ValueGetter<Color?>? fillColor,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+    ValueGetter<Color?>? borderColor,
+    ValueGetter<double?>? borderWidth,
+    ValueGetter<Clip?>? clipBehavior,
+    ValueGetter<List<BoxShadow>?>? boxShadow,
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+    ValueGetter<Duration?>? duration,
+  }) {
+    return CardTheme(
+      padding: padding == null ? this.padding : padding(),
+      filled: filled == null ? this.filled : filled(),
+      fillColor: fillColor == null ? this.fillColor : fillColor(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+      borderColor: borderColor == null ? this.borderColor : borderColor(),
+      borderWidth: borderWidth == null ? this.borderWidth : borderWidth(),
+      clipBehavior: clipBehavior == null ? this.clipBehavior : clipBehavior(),
+      boxShadow: boxShadow == null ? this.boxShadow : boxShadow(),
+      surfaceOpacity:
+          surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
+      surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+      duration: duration == null ? this.duration : duration(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CardTheme &&
+        other.padding == padding &&
+        other.filled == filled &&
+        other.fillColor == fillColor &&
+        other.borderRadius == borderRadius &&
+        other.borderColor == borderColor &&
+        other.borderWidth == borderWidth &&
+        other.clipBehavior == clipBehavior &&
+        other.boxShadow == boxShadow &&
+        other.surfaceOpacity == surfaceOpacity &&
+        other.surfaceBlur == surfaceBlur &&
+        other.duration == duration;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        padding,
+        filled,
+        fillColor,
+        borderRadius,
+        borderColor,
+        borderWidth,
+        clipBehavior,
+        boxShadow,
+        surfaceOpacity,
+        surfaceBlur,
+        duration,
+      );
+}
+
 class Card extends StatelessWidget {
   final Widget child;
   final EdgeInsetsGeometry? padding;
-  final bool filled;
+  final bool? filled;
   final Color? fillColor;
   final BorderRadiusGeometry? borderRadius;
   final Color? borderColor;
   final double? borderWidth;
-  final Clip clipBehavior;
+  final Clip? clipBehavior;
   final List<BoxShadow>? boxShadow;
   final double? surfaceOpacity;
   final double? surfaceBlur;
@@ -18,10 +131,10 @@ class Card extends StatelessWidget {
     super.key,
     required this.child,
     this.padding,
-    this.filled = false,
+    this.filled,
     this.fillColor,
     this.borderRadius,
-    this.clipBehavior = Clip.none,
+    this.clipBehavior,
     this.borderColor,
     this.borderWidth,
     this.boxShadow,
@@ -33,17 +146,73 @@ class Card extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<CardTheme>(context);
     final scaling = theme.scaling;
+    final padding = styleValue(
+      widgetValue: this.padding,
+      themeValue: compTheme?.padding,
+      defaultValue: EdgeInsets.all(16 * scaling),
+    );
+    final filled = styleValue(
+      widgetValue: this.filled,
+      themeValue: compTheme?.filled,
+      defaultValue: false,
+    );
+    final fillColor = styleValue(
+      widgetValue: this.fillColor,
+      themeValue: compTheme?.fillColor,
+      defaultValue: theme.colorScheme.border,
+    );
+    final borderRadius = styleValue(
+      widgetValue: this.borderRadius,
+      themeValue: compTheme?.borderRadius,
+      defaultValue: null,
+    );
+    final borderColor = styleValue(
+      widgetValue: this.borderColor,
+      themeValue: compTheme?.borderColor,
+      defaultValue: null,
+    );
+    final borderWidth = styleValue(
+      widgetValue: this.borderWidth,
+      themeValue: compTheme?.borderWidth,
+      defaultValue: null,
+    );
+    final clipBehavior = styleValue(
+      widgetValue: this.clipBehavior,
+      themeValue: compTheme?.clipBehavior,
+      defaultValue: Clip.none,
+    );
+    final boxShadow = styleValue(
+      widgetValue: this.boxShadow,
+      themeValue: compTheme?.boxShadow,
+      defaultValue: null,
+    );
+    final surfaceOpacity = styleValue(
+      widgetValue: this.surfaceOpacity,
+      themeValue: compTheme?.surfaceOpacity,
+      defaultValue: null,
+    );
+    final surfaceBlur = styleValue(
+      widgetValue: this.surfaceBlur,
+      themeValue: compTheme?.surfaceBlur,
+      defaultValue: null,
+    );
+    final duration = styleValue(
+      widgetValue: this.duration,
+      themeValue: compTheme?.duration,
+      defaultValue: null,
+    );
+
     return OutlinedContainer(
       clipBehavior: clipBehavior,
       borderRadius: borderRadius,
       borderWidth: borderWidth,
       borderColor: borderColor,
-      backgroundColor: filled
-          ? fillColor ?? theme.colorScheme.border
-          : theme.colorScheme.card,
+      backgroundColor:
+          filled ? fillColor : theme.colorScheme.card,
       boxShadow: boxShadow,
-      padding: padding ?? (EdgeInsets.all(16 * scaling)),
+      padding: padding,
       surfaceOpacity: surfaceOpacity,
       surfaceBlur: surfaceBlur,
       duration: duration,
@@ -60,12 +229,12 @@ class Card extends StatelessWidget {
 class SurfaceCard extends StatelessWidget {
   final Widget child;
   final EdgeInsetsGeometry? padding;
-  final bool filled;
+  final bool? filled;
   final Color? fillColor;
   final BorderRadiusGeometry? borderRadius;
   final Color? borderColor;
   final double? borderWidth;
-  final Clip clipBehavior;
+  final Clip? clipBehavior;
   final List<BoxShadow>? boxShadow;
   final double? surfaceOpacity;
   final double? surfaceBlur;
@@ -75,10 +244,10 @@ class SurfaceCard extends StatelessWidget {
     super.key,
     required this.child,
     this.padding,
-    this.filled = false,
+    this.filled,
     this.fillColor,
     this.borderRadius,
-    this.clipBehavior = Clip.none,
+    this.clipBehavior,
     this.borderColor,
     this.borderWidth,
     this.boxShadow,
@@ -90,12 +259,17 @@ class SurfaceCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<CardTheme>(context);
     var isSheetOverlay = SheetOverlayHandler.isSheetOverlay(context);
     final scaling = theme.scaling;
-    var padding = this.padding;
     if (isSheetOverlay) {
+      final padding = styleValue(
+        widgetValue: this.padding,
+        themeValue: compTheme?.padding,
+        defaultValue: EdgeInsets.all(16 * scaling),
+      );
       return Padding(
-        padding: padding ?? (EdgeInsets.all(16 * scaling)),
+        padding: padding,
         child: child,
       );
     }
@@ -108,9 +282,11 @@ class SurfaceCard extends StatelessWidget {
       fillColor: fillColor,
       boxShadow: boxShadow,
       padding: padding,
-      surfaceOpacity: surfaceOpacity ?? theme.surfaceOpacity,
-      surfaceBlur: surfaceBlur ?? theme.surfaceBlur,
-      duration: duration,
+      surfaceOpacity:
+          surfaceOpacity ?? compTheme?.surfaceOpacity ?? theme.surfaceOpacity,
+      surfaceBlur:
+          surfaceBlur ?? compTheme?.surfaceBlur ?? theme.surfaceBlur,
+      duration: duration ?? compTheme?.duration,
       child: child,
     );
   }

--- a/lib/src/components/layout/card_image.dart
+++ b/lib/src/components/layout/card_image.dart
@@ -1,5 +1,69 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class CardImageTheme {
+  final AbstractButtonStyle? style;
+  final Axis? direction;
+  final double? hoverScale;
+  final double? normalScale;
+  final Color? backgroundColor;
+  final Color? borderColor;
+  final double? gap;
+
+  const CardImageTheme({
+    this.style,
+    this.direction,
+    this.hoverScale,
+    this.normalScale,
+    this.backgroundColor,
+    this.borderColor,
+    this.gap,
+  });
+
+  CardImageTheme copyWith({
+    ValueGetter<AbstractButtonStyle?>? style,
+    ValueGetter<Axis?>? direction,
+    ValueGetter<double?>? hoverScale,
+    ValueGetter<double?>? normalScale,
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<Color?>? borderColor,
+    ValueGetter<double?>? gap,
+  }) {
+    return CardImageTheme(
+      style: style == null ? this.style : style(),
+      direction: direction == null ? this.direction : direction(),
+      hoverScale: hoverScale == null ? this.hoverScale : hoverScale(),
+      normalScale: normalScale == null ? this.normalScale : normalScale(),
+      backgroundColor:
+          backgroundColor == null ? this.backgroundColor : backgroundColor(),
+      borderColor: borderColor == null ? this.borderColor : borderColor(),
+      gap: gap == null ? this.gap : gap(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is CardImageTheme &&
+        other.style == style &&
+        other.direction == direction &&
+        other.hoverScale == hoverScale &&
+        other.normalScale == normalScale &&
+        other.backgroundColor == backgroundColor &&
+        other.borderColor == borderColor &&
+        other.gap == gap;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        style,
+        direction,
+        hoverScale,
+        normalScale,
+        backgroundColor,
+        borderColor,
+        gap,
+      );
+}
+
 class CardImage extends StatefulWidget {
   final Widget image;
   final Widget? title;
@@ -9,11 +73,12 @@ class CardImage extends StatefulWidget {
   final VoidCallback? onPressed;
   final bool? enabled;
   final AbstractButtonStyle? style;
-  final Axis direction;
-  final double hoverScale;
-  final double normalScale;
+  final Axis? direction;
+  final double? hoverScale;
+  final double? normalScale;
   final Color? backgroundColor;
   final Color? borderColor;
+  final double? gap;
 
   const CardImage({
     super.key,
@@ -25,11 +90,12 @@ class CardImage extends StatefulWidget {
     this.onPressed,
     this.enabled,
     this.style,
-    this.direction = Axis.vertical,
-    this.hoverScale = 1.05,
-    this.normalScale = 1,
-    this.backgroundColor = Colors.transparent,
-    this.borderColor = Colors.transparent,
+    this.direction,
+    this.hoverScale,
+    this.normalScale,
+    this.backgroundColor,
+    this.borderColor,
+    this.gap,
   });
 
   @override
@@ -39,8 +105,8 @@ class CardImage extends StatefulWidget {
 class _CardImageState extends State<CardImage> {
   final WidgetStatesController _statesController = WidgetStatesController();
 
-  Widget _wrapIntrinsic(Widget child) {
-    return widget.direction == Axis.horizontal
+  Widget _wrapIntrinsic(Widget child, Axis direction) {
+    return direction == Axis.horizontal
         ? IntrinsicHeight(child: child)
         : IntrinsicWidth(child: child);
   }
@@ -49,24 +115,51 @@ class _CardImageState extends State<CardImage> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<CardImageTheme>(context);
+    final style = styleValue(
+        widgetValue: widget.style,
+        themeValue: compTheme?.style,
+        defaultValue: const ButtonStyle.fixed(
+          density: ButtonDensity.compact,
+        ));
+    final direction = styleValue(
+        widgetValue: widget.direction,
+        themeValue: compTheme?.direction,
+        defaultValue: Axis.vertical);
+    final hoverScale = styleValue(
+        widgetValue: widget.hoverScale,
+        themeValue: compTheme?.hoverScale,
+        defaultValue: 1.05);
+    final normalScale = styleValue(
+        widgetValue: widget.normalScale,
+        themeValue: compTheme?.normalScale,
+        defaultValue: 1.0);
+    final backgroundColor = styleValue(
+        widgetValue: widget.backgroundColor,
+        themeValue: compTheme?.backgroundColor,
+        defaultValue: Colors.transparent);
+    final borderColor = styleValue(
+        widgetValue: widget.borderColor,
+        themeValue: compTheme?.borderColor,
+        defaultValue: Colors.transparent);
+    final gap = styleValue(
+        widgetValue: widget.gap,
+        themeValue: compTheme?.gap,
+        defaultValue: 12 * scaling);
     return Button(
       statesController: _statesController,
-      style: widget.style ??
-          const ButtonStyle.fixed(
-            density: ButtonDensity.compact,
-          ),
+      style: style,
       onPressed: widget.onPressed,
       enabled: widget.enabled,
       child: _wrapIntrinsic(
         Flex(
-          direction: widget.direction,
+          direction: direction,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Flexible(
               child: OutlinedContainer(
-                backgroundColor:
-                    widget.backgroundColor ?? theme.colorScheme.card,
-                borderColor: widget.borderColor ?? theme.colorScheme.border,
+                backgroundColor: backgroundColor ?? theme.colorScheme.card,
+                borderColor: borderColor ?? theme.colorScheme.border,
                 child: AnimatedBuilder(
                     animation: _statesController,
                     builder: (context, child) {
@@ -74,14 +167,14 @@ class _CardImageState extends State<CardImage> {
                         duration: kDefaultDuration,
                         scale: _statesController.value
                                 .contains(WidgetState.hovered)
-                            ? widget.hoverScale
-                            : widget.normalScale,
+                            ? hoverScale
+                            : normalScale,
                         child: widget.image,
                       );
                     }),
               ),
             ),
-            Gap(12 * scaling),
+            Gap(gap),
             Basic(
               title: widget.title,
               subtitle: widget.subtitle,
@@ -90,6 +183,7 @@ class _CardImageState extends State<CardImage> {
             ),
           ],
         ),
+        direction,
       ),
     );
   }

--- a/lib/src/components/layout/hidden.dart
+++ b/lib/src/components/layout/hidden.dart
@@ -1,48 +1,154 @@
 import 'package:flutter/rendering.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [Hidden].
+class HiddenTheme {
+  /// Direction of the hidden transition.
+  final Axis? direction;
+
+  /// Duration of the animation.
+  final Duration? duration;
+
+  /// Curve of the animation.
+  final Curve? curve;
+
+  /// Whether the widget is reversed.
+  final bool? reverse;
+
+  /// Whether to keep cross axis size when hidden.
+  final bool? keepCrossAxisSize;
+
+  /// Whether to keep main axis size when hidden.
+  final bool? keepMainAxisSize;
+
+  /// Creates a [HiddenTheme].
+  const HiddenTheme({
+    this.direction,
+    this.duration,
+    this.curve,
+    this.reverse,
+    this.keepCrossAxisSize,
+    this.keepMainAxisSize,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  HiddenTheme copyWith({
+    ValueGetter<Axis?>? direction,
+    ValueGetter<Duration?>? duration,
+    ValueGetter<Curve?>? curve,
+    ValueGetter<bool?>? reverse,
+    ValueGetter<bool?>? keepCrossAxisSize,
+    ValueGetter<bool?>? keepMainAxisSize,
+  }) {
+    return HiddenTheme(
+      direction: direction == null ? this.direction : direction(),
+      duration: duration == null ? this.duration : duration(),
+      curve: curve == null ? this.curve : curve(),
+      reverse: reverse == null ? this.reverse : reverse(),
+      keepCrossAxisSize: keepCrossAxisSize == null
+          ? this.keepCrossAxisSize
+          : keepCrossAxisSize(),
+      keepMainAxisSize: keepMainAxisSize == null
+          ? this.keepMainAxisSize
+          : keepMainAxisSize(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is HiddenTheme &&
+        other.direction == direction &&
+        other.duration == duration &&
+        other.curve == curve &&
+        other.reverse == reverse &&
+        other.keepCrossAxisSize == keepCrossAxisSize &&
+        other.keepMainAxisSize == keepMainAxisSize;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    direction,
+    duration,
+    curve,
+    reverse,
+    keepCrossAxisSize,
+    keepMainAxisSize,
+  );
+}
+
 class Hidden extends StatelessWidget {
   final bool hidden;
   final Widget child;
-  final Axis direction;
-  final bool reverse;
-  final Duration duration;
-  final Curve curve;
-  final bool keepCrossAxisSize;
-  final bool keepMainAxisSize;
+  final Axis? direction;
+  final bool? reverse;
+  final Duration? duration;
+  final Curve? curve;
+  final bool? keepCrossAxisSize;
+  final bool? keepMainAxisSize;
 
   const Hidden({
     super.key,
     required this.hidden,
     required this.child,
-    this.direction = Axis.horizontal,
-    this.duration = kDefaultDuration,
-    this.curve = Curves.easeInOut,
-    this.reverse = false,
-    this.keepCrossAxisSize = false,
-    this.keepMainAxisSize = false,
+    this.direction,
+    this.duration,
+    this.curve,
+    this.reverse,
+    this.keepCrossAxisSize,
+    this.keepMainAxisSize,
   });
 
   @override
   Widget build(BuildContext context) {
     final textDirection = Directionality.of(context);
-    var duration = this.duration;
+    final compTheme = ComponentTheme.maybeOf<HiddenTheme>(context);
+    final directionValue = styleValue(
+      widgetValue: direction,
+      themeValue: compTheme?.direction,
+      defaultValue: Axis.horizontal,
+    );
+    final durationValue = styleValue(
+      widgetValue: duration,
+      themeValue: compTheme?.duration,
+      defaultValue: kDefaultDuration,
+    );
+    final curveValue = styleValue(
+      widgetValue: curve,
+      themeValue: compTheme?.curve,
+      defaultValue: Curves.easeInOut,
+    );
+    final reverseValue = styleValue(
+      widgetValue: reverse,
+      themeValue: compTheme?.reverse,
+      defaultValue: false,
+    );
+    final keepCrossAxisSizeValue = styleValue(
+      widgetValue: keepCrossAxisSize,
+      themeValue: compTheme?.keepCrossAxisSize,
+      defaultValue: false,
+    );
+    final keepMainAxisSizeValue = styleValue(
+      widgetValue: keepMainAxisSize,
+      themeValue: compTheme?.keepMainAxisSize,
+      defaultValue: false,
+    );
     return AnimatedOpacity(
       opacity: hidden ? 0.0 : 1.0,
-      duration: duration,
-      curve: curve,
+      duration: durationValue,
+      curve: curveValue,
       child: AnimatedValueBuilder(
         value: hidden ? 0.0 : 1.0,
-        duration: duration,
-        curve: curve,
+        duration: durationValue,
+        curve: curveValue,
         child: child,
         builder: (context, value, child) {
           return _HiddenLayout(
-            keepCrossAxisSize: keepCrossAxisSize,
-            keepMainAxisSize: keepMainAxisSize,
+            keepCrossAxisSize: keepCrossAxisSizeValue,
+            keepMainAxisSize: keepMainAxisSizeValue,
             textDirection: textDirection,
-            direction: direction,
-            reverse: reverse,
+            direction: directionValue,
+            reverse: reverseValue,
             progress: value.clamp(0.0, 1.0),
             child: child,
           );
@@ -84,7 +190,9 @@ class _HiddenLayout extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(
-      BuildContext context, _RenderHiddenLayout renderObject) {
+    BuildContext context,
+    _RenderHiddenLayout renderObject,
+  ) {
     bool needsLayout = false;
     if (renderObject.textDirection != textDirection) {
       renderObject.textDirection = textDirection;
@@ -137,34 +245,39 @@ class _RenderHiddenLayout extends RenderBox
   @override
   double computeMaxIntrinsicHeight(double width) {
     return _computeIntrinsicHeight(
-        (RenderBox child, double width) => child.getMaxIntrinsicHeight(width),
-        width);
+      (RenderBox child, double width) => child.getMaxIntrinsicHeight(width),
+      width,
+    );
   }
 
   @override
   double computeMaxIntrinsicWidth(double height) {
     return _computeIntrinsicWidth(
-        (RenderBox child, double height) => child.getMaxIntrinsicWidth(height),
-        height);
+      (RenderBox child, double height) => child.getMaxIntrinsicWidth(height),
+      height,
+    );
   }
 
   @override
   double computeMinIntrinsicHeight(double width) {
     return _computeIntrinsicHeight(
-        (RenderBox child, double width) => child.getMinIntrinsicHeight(width),
-        width);
+      (RenderBox child, double width) => child.getMinIntrinsicHeight(width),
+      width,
+    );
   }
 
   @override
   double computeMinIntrinsicWidth(double height) {
     return _computeIntrinsicWidth(
-        (RenderBox child, double height) => child.getMinIntrinsicWidth(height),
-        height);
+      (RenderBox child, double height) => child.getMinIntrinsicWidth(height),
+      height,
+    );
   }
 
   double _computeIntrinsicWidth(
-      double Function(RenderBox child, double height) childWidth,
-      double height) {
+    double Function(RenderBox child, double height) childWidth,
+    double height,
+  ) {
     var child = this.child;
     if (child == null) {
       return 0;
@@ -177,8 +290,9 @@ class _RenderHiddenLayout extends RenderBox
   }
 
   double _computeIntrinsicHeight(
-      double Function(RenderBox child, double width) childHeight,
-      double width) {
+    double Function(RenderBox child, double width) childHeight,
+    double width,
+  ) {
     var child = this.child;
     if (child == null) {
       return 0;
@@ -196,11 +310,12 @@ class _RenderHiddenLayout extends RenderBox
     if (child != null) {
       var parentData = child.parentData as BoxParentData;
       return result.addWithPaintOffset(
-          offset: parentData.offset,
-          position: position,
-          hitTest: (result, position) {
-            return child.hitTest(result, position: position);
-          });
+        offset: parentData.offset,
+        position: position,
+        hitTest: (result, position) {
+          return child.hitTest(result, position: position);
+        },
+      );
     }
     return false;
   }
@@ -241,20 +356,28 @@ class _RenderHiddenLayout extends RenderBox
       if (reverse) {
         var parentData = child.parentData as BoxParentData;
         if (direction == Axis.horizontal) {
-          parentData.offset = Offset(size.width - preferredSize.width,
-              -(preferredSize.height - size.height) / 2);
+          parentData.offset = Offset(
+            size.width - preferredSize.width,
+            -(preferredSize.height - size.height) / 2,
+          );
         } else {
-          parentData.offset = Offset(-(preferredSize.width - size.width) / 2,
-              size.height - preferredSize.height);
+          parentData.offset = Offset(
+            -(preferredSize.width - size.width) / 2,
+            size.height - preferredSize.height,
+          );
         }
       } else {
         var parentData = child.parentData as BoxParentData;
         if (direction == Axis.horizontal) {
-          parentData.offset =
-              Offset(0, -(preferredSize.height - size.height) / 2);
+          parentData.offset = Offset(
+            0,
+            -(preferredSize.height - size.height) / 2,
+          );
         } else {
-          parentData.offset =
-              Offset(-(preferredSize.width - size.width) / 2, 0);
+          parentData.offset = Offset(
+            -(preferredSize.width - size.width) / 2,
+            0,
+          );
         }
       }
     } else {

--- a/lib/src/components/layout/outlined_container.dart
+++ b/lib/src/components/layout/outlined_container.dart
@@ -23,10 +23,7 @@ class _SurfaceBlurState extends State<SurfaceBlur> {
   @override
   Widget build(BuildContext context) {
     if (widget.surfaceBlur == null || widget.surfaceBlur! <= 0) {
-      return KeyedSubtree(
-        key: _mainContainerKey,
-        child: widget.child,
-      );
+      return KeyedSubtree(key: _mainContainerKey, child: widget.child);
     }
     return Stack(
       fit: StackFit.passthrough,
@@ -44,13 +41,90 @@ class _SurfaceBlurState extends State<SurfaceBlur> {
             ),
           ),
         ),
-        KeyedSubtree(
-          key: _mainContainerKey,
-          child: widget.child,
-        ),
+        KeyedSubtree(key: _mainContainerKey, child: widget.child),
       ],
     );
   }
+}
+
+class OutlinedContainerTheme {
+  final Color? backgroundColor;
+  final Color? borderColor;
+  final BorderRadiusGeometry? borderRadius;
+  final BorderStyle? borderStyle;
+  final double? borderWidth;
+  final List<BoxShadow>? boxShadow;
+  final EdgeInsetsGeometry? padding;
+  final double? surfaceOpacity;
+  final double? surfaceBlur;
+
+  const OutlinedContainerTheme({
+    this.backgroundColor,
+    this.borderColor,
+    this.borderRadius,
+    this.borderStyle,
+    this.borderWidth,
+    this.boxShadow,
+    this.padding,
+    this.surfaceOpacity,
+    this.surfaceBlur,
+  });
+
+  OutlinedContainerTheme copyWith({
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<Color?>? borderColor,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+    ValueGetter<BorderStyle?>? borderStyle,
+    ValueGetter<double?>? borderWidth,
+    ValueGetter<List<BoxShadow>?>? boxShadow,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+  }) {
+    return OutlinedContainerTheme(
+      backgroundColor: backgroundColor == null
+          ? this.backgroundColor
+          : backgroundColor(),
+      borderColor: borderColor == null ? this.borderColor : borderColor(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+      borderStyle: borderStyle == null ? this.borderStyle : borderStyle(),
+      borderWidth: borderWidth == null ? this.borderWidth : borderWidth(),
+      boxShadow: boxShadow == null ? this.boxShadow : boxShadow(),
+      padding: padding == null ? this.padding : padding(),
+      surfaceOpacity: surfaceOpacity == null
+          ? this.surfaceOpacity
+          : surfaceOpacity(),
+      surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is OutlinedContainerTheme &&
+        other.backgroundColor == backgroundColor &&
+        other.borderColor == borderColor &&
+        other.borderRadius == borderRadius &&
+        other.borderStyle == borderStyle &&
+        other.borderWidth == borderWidth &&
+        other.boxShadow == boxShadow &&
+        other.padding == padding &&
+        other.surfaceOpacity == surfaceOpacity &&
+        other.surfaceBlur == surfaceBlur;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    backgroundColor,
+    borderColor,
+    borderRadius,
+    borderStyle,
+    borderWidth,
+    boxShadow,
+    padding,
+    surfaceOpacity,
+    surfaceBlur,
+  );
 }
 
 class OutlinedContainer extends StatefulWidget {
@@ -96,14 +170,51 @@ class _OutlinedContainerState extends State<OutlinedContainer> {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final scaling = theme.scaling;
-    var borderRadius =
-        widget.borderRadius?.resolve(Directionality.of(context)) ??
-            BorderRadius.circular(theme.radiusXl);
-    var backgroundColor =
-        widget.backgroundColor ?? theme.colorScheme.background;
-    if (widget.surfaceOpacity != null) {
-      backgroundColor = backgroundColor.scaleAlpha(widget.surfaceOpacity!);
+    final compTheme = ComponentTheme.maybeOf<OutlinedContainerTheme>(context);
+    var borderRadius = styleValue(
+      defaultValue: theme.borderRadiusXl,
+      themeValue: compTheme?.borderRadius,
+      widgetValue: widget.borderRadius,
+    ).resolve(Directionality.of(context));
+    var backgroundColor = styleValue(
+      defaultValue: theme.colorScheme.background,
+      themeValue: compTheme?.backgroundColor,
+      widgetValue: widget.backgroundColor,
+    );
+    final double? surfaceOpacity = styleValue(
+      themeValue: compTheme?.surfaceOpacity,
+      widgetValue: widget.surfaceOpacity,
+    );
+    if (surfaceOpacity != null) {
+      backgroundColor = backgroundColor.scaleAlpha(surfaceOpacity);
     }
+    final borderColor = styleValue(
+      defaultValue: theme.colorScheme.muted,
+      themeValue: compTheme?.borderColor,
+      widgetValue: widget.borderColor,
+    );
+    final borderWidth = styleValue(
+      defaultValue: 1 * scaling,
+      themeValue: compTheme?.borderWidth,
+      widgetValue: widget.borderWidth,
+    );
+    final borderStyle = styleValue<BorderStyle>(
+      defaultValue: BorderStyle.solid,
+      themeValue: compTheme?.borderStyle,
+      widgetValue: widget.borderStyle,
+    );
+    final boxShadow = styleValue<List<BoxShadow>>(
+      themeValue: compTheme?.boxShadow,
+      widgetValue: widget.boxShadow,
+    );
+    final padding = styleValue<EdgeInsetsGeometry>(
+      themeValue: compTheme?.padding,
+      widgetValue: widget.padding,
+    );
+    final surfaceBlur = styleValue<double>(
+      themeValue: compTheme?.surfaceBlur,
+      widgetValue: widget.surfaceBlur,
+    );
     Widget childWidget = AnimatedContainer(
       duration: widget.duration ?? Duration.zero,
       key: _mainContainerKey,
@@ -112,33 +223,27 @@ class _OutlinedContainerState extends State<OutlinedContainer> {
       decoration: BoxDecoration(
         color: backgroundColor,
         border: Border.all(
-          color: widget.borderColor ?? theme.colorScheme.muted,
-          width: widget.borderWidth ?? (1 * scaling),
-          style: widget.borderStyle ?? BorderStyle.solid,
+          color: borderColor,
+          width: borderWidth,
+          style: borderStyle,
         ),
         borderRadius: borderRadius,
-        boxShadow: widget.boxShadow,
+        boxShadow: boxShadow,
       ),
       child: AnimatedContainer(
         duration: widget.duration ?? Duration.zero,
-        padding: widget.padding,
+        padding: padding,
         clipBehavior: widget.clipBehavior,
         decoration: BoxDecoration(
-          borderRadius: subtractByBorder(
-            borderRadius,
-            widget.borderWidth ?? (1 * scaling),
-          ),
+          borderRadius: subtractByBorder(borderRadius, borderWidth),
         ),
         child: widget.child,
       ),
     );
-    if (widget.surfaceBlur != null && widget.surfaceBlur! > 0) {
+    if (surfaceBlur != null && surfaceBlur > 0) {
       childWidget = SurfaceBlur(
-        surfaceBlur: widget.surfaceBlur!,
-        borderRadius: subtractByBorder(
-          borderRadius,
-          widget.borderWidth ?? (1 * scaling),
-        ),
+        surfaceBlur: surfaceBlur,
+        borderRadius: subtractByBorder(borderRadius, borderWidth),
         child: childWidget,
       );
     }
@@ -192,24 +297,25 @@ class DashedLine extends StatelessWidget {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
     return AnimatedValueBuilder(
-        value: DashedLineProperties(
-          width: width ?? (8 * scaling),
-          gap: gap ?? (5 * scaling),
-          thickness: thickness ?? (1 * scaling),
-          color: color ?? theme.colorScheme.border,
-        ),
-        duration: kDefaultDuration,
-        lerp: DashedLineProperties.lerp,
-        builder: (context, value, child) {
-          return CustomPaint(
-            painter: DashedLinePainter(
-              width: value.width,
-              gap: value.gap,
-              thickness: value.thickness,
-              color: value.color,
-            ),
-          );
-        });
+      value: DashedLineProperties(
+        width: width ?? (8 * scaling),
+        gap: gap ?? (5 * scaling),
+        thickness: thickness ?? (1 * scaling),
+        color: color ?? theme.colorScheme.border,
+      ),
+      duration: kDefaultDuration,
+      lerp: DashedLineProperties.lerp,
+      builder: (context, value, child) {
+        return CustomPaint(
+          painter: DashedLinePainter(
+            width: value.width,
+            gap: value.gap,
+            thickness: value.thickness,
+            color: value.color,
+          ),
+        );
+      },
+    );
   }
 }
 
@@ -239,8 +345,11 @@ class DashedContainerProperties {
       gap: lerpDouble(a.gap, b.gap, t)!,
       thickness: lerpDouble(a.thickness, b.thickness, t)!,
       color: Color.lerp(a.color, b.color, t)!,
-      borderRadius: BorderRadius.lerp(a.borderRadius.optionallyResolve(context),
-          b.borderRadius.optionallyResolve(context), t)!,
+      borderRadius: BorderRadius.lerp(
+        a.borderRadius.optionallyResolve(context),
+        b.borderRadius.optionallyResolve(context),
+        t,
+      )!,
     );
   }
 }
@@ -322,10 +431,7 @@ class DashedLinePainter extends CustomPainter {
         if (end > pathMetric.length) {
           end = pathMetric.length;
         }
-        draw.addPath(
-          pathMetric.extractPath(start, end),
-          Offset.zero,
-        );
+        draw.addPath(pathMetric.extractPath(start, end), Offset.zero);
       }
     }
     canvas.drawPath(
@@ -365,13 +471,15 @@ class DashedPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     Path path = Path();
     if (borderRadius != null && borderRadius != BorderRadius.zero) {
-      path.addRRect(RRect.fromRectAndCorners(
-        Rect.fromLTWH(0, 0, size.width, size.height),
-        topLeft: borderRadius!.topLeft,
-        topRight: borderRadius!.topRight,
-        bottomLeft: borderRadius!.bottomLeft,
-        bottomRight: borderRadius!.bottomRight,
-      ));
+      path.addRRect(
+        RRect.fromRectAndCorners(
+          Rect.fromLTWH(0, 0, size.width, size.height),
+          topLeft: borderRadius!.topLeft,
+          topRight: borderRadius!.topRight,
+          bottomLeft: borderRadius!.bottomLeft,
+          bottomRight: borderRadius!.bottomRight,
+        ),
+      );
     } else {
       path.addRect(Rect.fromLTWH(0, 0, size.width, size.height));
     }
@@ -385,10 +493,7 @@ class DashedPainter extends CustomPainter {
         if (end > pathMetric.length) {
           end = pathMetric.length;
         }
-        draw.addPath(
-          pathMetric.extractPath(start, end),
-          Offset.zero,
-        );
+        draw.addPath(pathMetric.extractPath(start, end), Offset.zero);
       }
     }
     canvas.drawPath(

--- a/lib/src/components/layout/stage_container.dart
+++ b/lib/src/components/layout/stage_container.dart
@@ -2,9 +2,14 @@ import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 
+import '../../../shadcn_flutter.dart';
+
 abstract class StageBreakpoint {
-  factory StageBreakpoint.constant(double breakpoint,
-      {double minSize = 0, double maxSize = double.infinity}) {
+  factory StageBreakpoint.constant(
+    double breakpoint, {
+    double minSize = 0,
+    double maxSize = double.infinity,
+  }) {
     return ConstantBreakpoint(breakpoint, minSize: minSize, maxSize: maxSize);
   }
 
@@ -28,8 +33,11 @@ class ConstantBreakpoint implements StageBreakpoint {
   @override
   final double maxSize;
 
-  const ConstantBreakpoint(this.breakpoint,
-      {this.minSize = 0, this.maxSize = double.infinity});
+  const ConstantBreakpoint(
+    this.breakpoint, {
+    this.minSize = 0,
+    this.maxSize = double.infinity,
+  });
 
   @override
   double getMinWidth(double width) {
@@ -46,18 +54,12 @@ class ConstantBreakpoint implements StageBreakpoint {
 }
 
 class StagedBreakpoint implements StageBreakpoint {
-  static const List<double> _defaultBreakpoints = [
-    576,
-    768,
-    992,
-    1200,
-    1400,
-  ];
+  static const List<double> _defaultBreakpoints = [576, 768, 992, 1200, 1400];
   final List<double> breakpoints;
 
   const StagedBreakpoint(this.breakpoints) : assert(breakpoints.length > 1);
   const StagedBreakpoint.defaultBreakpoints()
-      : breakpoints = _defaultBreakpoints;
+    : breakpoints = _defaultBreakpoints;
 
   @override
   double getMinWidth(double width) {
@@ -86,6 +88,34 @@ class StagedBreakpoint implements StageBreakpoint {
   double get maxSize => breakpoints.last;
 }
 
+class StageContainerTheme {
+  final StageBreakpoint? breakpoint;
+  final EdgeInsets? padding;
+
+  const StageContainerTheme({this.breakpoint, this.padding});
+
+  StageContainerTheme copyWith({
+    ValueGetter<StageBreakpoint?>? breakpoint,
+    ValueGetter<EdgeInsets?>? padding,
+  }) {
+    return StageContainerTheme(
+      breakpoint: breakpoint == null ? this.breakpoint : breakpoint(),
+      padding: padding == null ? this.padding : padding(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is StageContainerTheme &&
+        other.breakpoint == breakpoint &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(breakpoint, padding);
+}
+
 class StageContainer extends StatelessWidget {
   final StageBreakpoint breakpoint;
   final Widget Function(BuildContext context, EdgeInsets padding) builder;
@@ -100,6 +130,12 @@ class StageContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<StageContainerTheme>(context);
+    final StageBreakpoint breakpoint = compTheme?.breakpoint ?? this.breakpoint;
+    final EdgeInsets padding = styleValue(
+      defaultValue: this.padding,
+      themeValue: compTheme?.padding,
+    );
     return LayoutBuilder(
       builder: (context, constraints) {
         var size = constraints.maxWidth;
@@ -108,12 +144,7 @@ class StageContainer extends StatelessWidget {
         double leftPadding = padding.left;
         double rightPadding = padding.right;
         if (size < breakpoint.minSize) {
-          return builder(
-              context,
-              padding.copyWith(
-                left: 0,
-                right: 0,
-              ));
+          return builder(context, padding.copyWith(left: 0, right: 0));
         } else if (size > breakpoint.maxSize) {
           double remainingWidth = (size - breakpoint.maxSize) / 2;
           leftPadding += remainingWidth;
@@ -121,31 +152,35 @@ class StageContainer extends StatelessWidget {
           leftPadding = max(0, leftPadding);
           rightPadding = max(0, rightPadding);
           return builder(
-              context,
-              EdgeInsets.only(
-                top: topPadding,
-                bottom: bottomPadding,
-                left: leftPadding,
-                right: rightPadding,
-              ));
-        }
-        double minWidth = breakpoint.getMinWidth(size);
-        double maxWidth = breakpoint.getMaxWidth(size);
-        assert(minWidth <= maxWidth,
-            'minWidth must be less than or equal to maxWidth ($minWidth > $maxWidth)');
-        double remainingWidth = (size - minWidth) / 2;
-        leftPadding += remainingWidth;
-        rightPadding += remainingWidth;
-        leftPadding = max(0, leftPadding);
-        rightPadding = max(0, rightPadding);
-        return builder(
             context,
             EdgeInsets.only(
               top: topPadding,
               bottom: bottomPadding,
               left: leftPadding,
               right: rightPadding,
-            ));
+            ),
+          );
+        }
+        double minWidth = breakpoint.getMinWidth(size);
+        double maxWidth = breakpoint.getMaxWidth(size);
+        assert(
+          minWidth <= maxWidth,
+          'minWidth must be less than or equal to maxWidth ($minWidth > $maxWidth)',
+        );
+        double remainingWidth = (size - minWidth) / 2;
+        leftPadding += remainingWidth;
+        rightPadding += remainingWidth;
+        leftPadding = max(0, leftPadding);
+        rightPadding = max(0, rightPadding);
+        return builder(
+          context,
+          EdgeInsets.only(
+            top: topPadding,
+            bottom: bottomPadding,
+            left: leftPadding,
+            right: rightPadding,
+          ),
+        );
       },
     );
   }

--- a/lib/src/components/menu/popup.dart
+++ b/lib/src/components/menu/popup.dart
@@ -1,14 +1,96 @@
 import '../../../shadcn_flutter.dart';
 
+/// A theme for [MenuPopup].
+class MenuPopupTheme {
+  /// The opacity of the surface.
+  final double? surfaceOpacity;
+
+  /// The blur applied to the surface.
+  final double? surfaceBlur;
+
+  /// The padding inside the popup.
+  final EdgeInsetsGeometry? padding;
+
+  /// The background color of the popup.
+  final Color? fillColor;
+
+  /// The border color of the popup.
+  final Color? borderColor;
+
+  /// The border radius of the popup.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Creates a [MenuPopupTheme].
+  const MenuPopupTheme({
+    this.surfaceOpacity,
+    this.surfaceBlur,
+    this.padding,
+    this.fillColor,
+    this.borderColor,
+    this.borderRadius,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  MenuPopupTheme copyWith({
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<Color?>? fillColor,
+    ValueGetter<Color?>? borderColor,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+  }) {
+    return MenuPopupTheme(
+      surfaceOpacity:
+          surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
+      surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+      padding: padding == null ? this.padding : padding(),
+      fillColor: fillColor == null ? this.fillColor : fillColor(),
+      borderColor: borderColor == null ? this.borderColor : borderColor(),
+      borderRadius:
+          borderRadius == null ? this.borderRadius : borderRadius(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is MenuPopupTheme &&
+        other.surfaceOpacity == surfaceOpacity &&
+        other.surfaceBlur == surfaceBlur &&
+        other.padding == padding &&
+        other.fillColor == fillColor &&
+        other.borderColor == borderColor &&
+        other.borderRadius == borderRadius;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        surfaceOpacity,
+        surfaceBlur,
+        padding,
+        fillColor,
+        borderColor,
+        borderRadius,
+      );
+}
+
 class MenuPopup extends StatelessWidget {
   final double? surfaceOpacity;
   final double? surfaceBlur;
+  final EdgeInsetsGeometry? padding;
+  final Color? fillColor;
+  final Color? borderColor;
+  final BorderRadiusGeometry? borderRadius;
   final List<Widget> children;
 
   const MenuPopup({
     super.key,
     this.surfaceOpacity,
     this.surfaceBlur,
+    this.padding,
+    this.fillColor,
+    this.borderColor,
+    this.borderRadius,
     required this.children,
   });
 
@@ -26,19 +108,39 @@ class MenuPopup extends StatelessWidget {
   Widget build(BuildContext context) {
     final data = Data.maybeOf<MenuGroupData>(context);
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<MenuPopupTheme>(context);
     final isSheetOverlay = SheetOverlayHandler.isSheetOverlay(context);
     final isDialogOverlay = DialogOverlayHandler.isDialogOverlay(context);
+    final pad = styleValue(
+        widgetValue: padding,
+        themeValue: compTheme?.padding,
+        defaultValue: isSheetOverlay
+            ? const EdgeInsets.symmetric(vertical: 12, horizontal: 4) *
+                theme.scaling
+            : const EdgeInsets.all(4) * theme.scaling);
     return ModalContainer(
-      borderRadius: theme.borderRadiusMd,
+      borderRadius: styleValue(
+          widgetValue: borderRadius,
+          themeValue: compTheme?.borderRadius,
+          defaultValue: theme.borderRadiusMd),
       filled: true,
-      fillColor: theme.colorScheme.popover,
-      borderColor: theme.colorScheme.border,
-      surfaceBlur: surfaceBlur ?? theme.surfaceBlur,
-      surfaceOpacity: surfaceOpacity ?? theme.surfaceOpacity,
-      padding: isSheetOverlay
-          ? const EdgeInsets.symmetric(vertical: 12, horizontal: 4) *
-              theme.scaling
-          : const EdgeInsets.all(4) * theme.scaling,
+      fillColor: styleValue(
+          widgetValue: fillColor,
+          themeValue: compTheme?.fillColor,
+          defaultValue: theme.colorScheme.popover),
+      borderColor: styleValue(
+          widgetValue: borderColor,
+          themeValue: compTheme?.borderColor,
+          defaultValue: theme.colorScheme.border),
+      surfaceBlur: styleValue(
+          widgetValue: surfaceBlur,
+          themeValue: compTheme?.surfaceBlur,
+          defaultValue: theme.surfaceBlur),
+      surfaceOpacity: styleValue(
+          widgetValue: surfaceOpacity,
+          themeValue: compTheme?.surfaceOpacity,
+          defaultValue: theme.surfaceOpacity),
+      padding: pad,
       child: SingleChildScrollView(
         scrollDirection: data?.direction ?? Axis.vertical,
         child: _buildIntrinsicContainer(

--- a/lib/src/components/navigation/pagination.dart
+++ b/lib/src/components/navigation/pagination.dart
@@ -1,5 +1,45 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// A theme for [Pagination].
+class PaginationTheme {
+  /// The spacing between pagination controls.
+  final double? gap;
+
+  /// Whether to show the previous/next labels.
+  final bool? showLabel;
+
+  /// Creates a [PaginationTheme].
+  const PaginationTheme({
+    this.gap,
+    this.showLabel,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  PaginationTheme copyWith({
+    ValueGetter<double?>? gap,
+    ValueGetter<bool?>? showLabel,
+  }) {
+    return PaginationTheme(
+      gap: gap == null ? this.gap : gap(),
+      showLabel: showLabel == null ? this.showLabel : showLabel(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is PaginationTheme &&
+        other.gap == gap &&
+        other.showLabel == showLabel;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        gap,
+        showLabel,
+      );
+}
+
 class Pagination extends StatelessWidget {
   final int page;
   final int totalPages;
@@ -11,7 +51,8 @@ class Pagination extends StatelessWidget {
   final bool showSkipToLastPage;
   final bool hidePreviousOnFirstPage;
   final bool hideNextOnLastPage;
-  final bool showLabel;
+  final bool? showLabel;
+  final double? gap;
 
   const Pagination({
     super.key,
@@ -23,7 +64,8 @@ class Pagination extends StatelessWidget {
     this.showSkipToLastPage = true,
     this.hidePreviousOnFirstPage = false,
     this.hideNextOnLastPage = false,
-    this.showLabel = true,
+    this.showLabel,
+    this.gap,
   });
 
   bool get hasPrevious => page > 1;
@@ -66,7 +108,8 @@ class Pagination extends StatelessWidget {
   bool get hasMorePreviousPages => firstShownPage > 1;
   bool get hasMoreNextPages => lastShownPage < totalPages;
 
-  Widget _buildPreviousLabel(ShadcnLocalizations localizations) {
+  Widget _buildPreviousLabel(
+      ShadcnLocalizations localizations, bool showLabel) {
     if (showLabel) {
       return GhostButton(
         onPressed: hasPrevious ? () => onPageChanged(page - 1) : null,
@@ -80,7 +123,8 @@ class Pagination extends StatelessWidget {
     );
   }
 
-  Widget _buildNextLabel(ShadcnLocalizations localizations) {
+  Widget _buildNextLabel(
+      ShadcnLocalizations localizations, bool showLabel) {
     if (showLabel) {
       return GhostButton(
         onPressed: hasNext ? () => onPageChanged(page + 1) : null,
@@ -98,6 +142,15 @@ class Pagination extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<PaginationTheme>(context);
+    final gap = styleValue(
+        widgetValue: this.gap,
+        themeValue: compTheme?.gap,
+        defaultValue: 4 * scaling);
+    final showLabel = styleValue(
+        widgetValue: this.showLabel,
+        themeValue: compTheme?.showLabel,
+        defaultValue: true);
     ShadcnLocalizations localizations = ShadcnLocalizations.of(context);
     return IntrinsicHeight(
       child: Row(
@@ -105,7 +158,7 @@ class Pagination extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           if (!hidePreviousOnFirstPage || hasPrevious)
-            _buildPreviousLabel(localizations),
+            _buildPreviousLabel(localizations, showLabel),
           if (hasMorePreviousPages) ...[
             if (showSkipToFirstPage && firstShownPage - 1 > 1)
               GhostButton(
@@ -139,9 +192,10 @@ class Pagination extends StatelessWidget {
                 child: Text('$totalPages'),
               ),
           ],
-          if (!hideNextOnLastPage || hasNext) _buildNextLabel(localizations),
+          if (!hideNextOnLastPage || hasNext)
+            _buildNextLabel(localizations, showLabel),
         ],
-      ).gap(4 * scaling),
+      ).gap(gap),
     );
   }
 }

--- a/lib/src/components/navigation/tabs/tab_list.dart
+++ b/lib/src/components/navigation/tabs/tab_list.dart
@@ -1,5 +1,51 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class TabListTheme {
+  final Color? borderColor;
+  final double? borderWidth;
+  final Color? indicatorColor;
+  final double? indicatorHeight;
+
+  const TabListTheme({
+    this.borderColor,
+    this.borderWidth,
+    this.indicatorColor,
+    this.indicatorHeight,
+  });
+
+  TabListTheme copyWith({
+    ValueGetter<Color?>? borderColor,
+    ValueGetter<double?>? borderWidth,
+    ValueGetter<Color?>? indicatorColor,
+    ValueGetter<double?>? indicatorHeight,
+  }) {
+    return TabListTheme(
+      borderColor: borderColor == null ? this.borderColor : borderColor(),
+      borderWidth: borderWidth == null ? this.borderWidth : borderWidth(),
+      indicatorColor: indicatorColor == null
+          ? this.indicatorColor
+          : indicatorColor(),
+      indicatorHeight: indicatorHeight == null
+          ? this.indicatorHeight
+          : indicatorHeight(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TabListTheme &&
+        other.borderColor == borderColor &&
+        other.borderWidth == borderWidth &&
+        other.indicatorColor == indicatorColor &&
+        other.indicatorHeight == indicatorHeight;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(borderColor, borderWidth, indicatorColor, indicatorHeight);
+}
+
 class TabList extends StatelessWidget {
   final List<TabChild> children;
   final int index;
@@ -13,8 +59,20 @@ class TabList extends StatelessWidget {
   });
 
   Widget _childBuilder(
-      BuildContext context, TabContainerData data, Widget child) {
+    BuildContext context,
+    TabContainerData data,
+    Widget child,
+  ) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<TabListTheme>(context);
+    final indicatorColor = styleValue(
+      defaultValue: theme.colorScheme.primary,
+      themeValue: compTheme?.indicatorColor,
+    );
+    final indicatorHeight = styleValue(
+      defaultValue: 2 * theme.scaling,
+      themeValue: compTheme?.indicatorHeight,
+    );
     child = TabButton(
       enabled: data.onSelect != null,
       onPressed: () {
@@ -31,10 +89,7 @@ class TabList extends StatelessWidget {
             bottom: 0,
             left: 0,
             right: 0,
-            child: Container(
-              height: 2 * theme.scaling,
-              color: theme.colorScheme.primary,
-            ),
+            child: Container(height: indicatorHeight, color: indicatorColor),
           ),
       ],
     );
@@ -44,25 +99,30 @@ class TabList extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<TabListTheme>(context);
+    final borderColor = styleValue(
+      defaultValue: theme.colorScheme.border,
+      themeValue: compTheme?.borderColor,
+    );
+    final borderWidth = styleValue(
+      defaultValue: 1 * scaling,
+      themeValue: compTheme?.borderWidth,
+    );
     return TabContainer(
-        selected: index,
-        onSelect: onChanged,
-        builder: (context, children) {
-          return Container(
-            decoration: BoxDecoration(
-              border: Border(
-                bottom: BorderSide(
-                  color: theme.colorScheme.border,
-                  width: 1 * scaling,
-                ),
-              ),
+      selected: index,
+      onSelect: onChanged,
+      builder: (context, children) {
+        return Container(
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(color: borderColor, width: borderWidth),
             ),
-            child: Row(
-              children: children,
-            ),
-          );
-        },
-        childBuilder: _childBuilder,
-        children: children);
+          ),
+          child: Row(children: children),
+        );
+      },
+      childBuilder: _childBuilder,
+      children: children,
+    );
   }
 }

--- a/lib/src/components/navigation/tabs/tabs.dart
+++ b/lib/src/components/navigation/tabs/tabs.dart
@@ -1,5 +1,51 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class TabsTheme {
+  final EdgeInsetsGeometry? containerPadding;
+  final EdgeInsetsGeometry? tabPadding;
+  final Color? backgroundColor;
+  final BorderRadiusGeometry? borderRadius;
+
+  const TabsTheme({
+    this.containerPadding,
+    this.tabPadding,
+    this.backgroundColor,
+    this.borderRadius,
+  });
+
+  TabsTheme copyWith({
+    ValueGetter<EdgeInsetsGeometry?>? containerPadding,
+    ValueGetter<EdgeInsetsGeometry?>? tabPadding,
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+  }) {
+    return TabsTheme(
+      containerPadding: containerPadding == null
+          ? this.containerPadding
+          : containerPadding(),
+      tabPadding: tabPadding == null ? this.tabPadding : tabPadding(),
+      backgroundColor: backgroundColor == null
+          ? this.backgroundColor
+          : backgroundColor(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TabsTheme &&
+        other.containerPadding == containerPadding &&
+        other.tabPadding == tabPadding &&
+        other.backgroundColor == backgroundColor &&
+        other.borderRadius == borderRadius;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(containerPadding, tabPadding, backgroundColor, borderRadius);
+}
+
 class Tabs extends StatelessWidget {
   final int index;
   final ValueChanged<int> onChanged;
@@ -15,9 +61,19 @@ class Tabs extends StatelessWidget {
   });
 
   Widget _childBuilder(
-      BuildContext context, TabContainerData data, Widget child) {
+    BuildContext context,
+    TabContainerData data,
+    Widget child,
+  ) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<TabsTheme>(context);
+    final tabPadding = styleValue(
+      defaultValue:
+          const EdgeInsets.symmetric(horizontal: 16, vertical: 4) * scaling,
+      themeValue: compTheme?.tabPadding,
+      widgetValue: padding,
+    );
     final i = data.index;
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
@@ -29,19 +85,13 @@ class Tabs extends StatelessWidget {
         cursor: SystemMouseCursors.click,
         child: AnimatedContainer(
           duration: const Duration(
-              milliseconds: 50), // slightly faster than kDefaultDuration
+            milliseconds: 50,
+          ), // slightly faster than kDefaultDuration
           alignment: Alignment.center,
-          padding: padding ??
-              const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 4,
-                  ) *
-                  scaling,
+          padding: tabPadding,
           decoration: BoxDecoration(
             color: i == index ? theme.colorScheme.background : null,
-            borderRadius: BorderRadius.circular(
-              theme.radiusMd,
-            ),
+            borderRadius: BorderRadius.circular(theme.radiusMd),
           ),
           child: (i == index ? child.foreground() : child.muted())
               .small()
@@ -55,16 +105,31 @@ class Tabs extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<TabsTheme>(context);
+    final containerPadding = styleValue(
+      defaultValue: const EdgeInsets.all(4) * scaling,
+      themeValue: compTheme?.containerPadding,
+    );
+    final backgroundColor = styleValue(
+      defaultValue: theme.colorScheme.muted,
+      themeValue: compTheme?.backgroundColor,
+    );
+    final borderRadius = styleValue(
+      defaultValue: BorderRadius.circular(theme.radiusLg),
+      themeValue: compTheme?.borderRadius,
+    );
     return TabContainer(
       selected: index,
       onSelect: onChanged,
       builder: (context, children) {
         return Container(
           decoration: BoxDecoration(
-            color: theme.colorScheme.muted,
-            borderRadius: BorderRadius.circular(theme.radiusLg),
+            color: backgroundColor,
+            borderRadius: borderRadius is BorderRadius
+                ? borderRadius
+                : borderRadius?.resolve(Directionality.of(context)),
           ),
-          padding: const EdgeInsets.all(4) * scaling,
+          padding: containerPadding,
           child: IntrinsicHeight(
             child: Row(
               mainAxisSize: MainAxisSize.min,

--- a/lib/src/components/overlay/dialog.dart
+++ b/lib/src/components/overlay/dialog.dart
@@ -1,5 +1,58 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class ModalBackdropTheme {
+  final BorderRadiusGeometry? borderRadius;
+  final EdgeInsetsGeometry? padding;
+  final Color? barrierColor;
+  final bool? modal;
+  final bool? surfaceClip;
+
+  const ModalBackdropTheme({
+    this.borderRadius,
+    this.padding,
+    this.barrierColor,
+    this.modal,
+    this.surfaceClip,
+  });
+
+  ModalBackdropTheme copyWith({
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<Color?>? barrierColor,
+    ValueGetter<bool?>? modal,
+    ValueGetter<bool?>? surfaceClip,
+  }) {
+    return ModalBackdropTheme(
+      borderRadius:
+          borderRadius == null ? this.borderRadius : borderRadius(),
+      padding: padding == null ? this.padding : padding(),
+      barrierColor:
+          barrierColor == null ? this.barrierColor : barrierColor(),
+      modal: modal == null ? this.modal : modal(),
+      surfaceClip: surfaceClip == null ? this.surfaceClip : surfaceClip(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ModalBackdropTheme &&
+        other.borderRadius == borderRadius &&
+        other.padding == padding &&
+        other.barrierColor == barrierColor &&
+        other.modal == modal &&
+        other.surfaceClip == surfaceClip;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        borderRadius,
+        padding,
+        barrierColor,
+        modal,
+        surfaceClip,
+      );
+}
+
 class ModalBackdrop extends StatelessWidget {
   static bool shouldClipSurface(double? surfaceOpacity) {
     if (surfaceOpacity == null) {
@@ -9,26 +62,47 @@ class ModalBackdrop extends StatelessWidget {
   }
 
   final Widget child;
-  final BorderRadiusGeometry borderRadius;
-  final EdgeInsetsGeometry padding;
-  final Color barrierColor;
+  final BorderRadiusGeometry? borderRadius;
+  final EdgeInsetsGeometry? padding;
+  final Color? barrierColor;
   final Animation<double>? fadeAnimation;
-  final bool modal;
-  final bool surfaceClip;
+  final bool? modal;
+  final bool? surfaceClip;
 
   const ModalBackdrop({
     super.key,
-    this.modal = true,
-    this.surfaceClip = true,
-    this.borderRadius = BorderRadius.zero,
-    this.barrierColor = const Color.fromRGBO(0, 0, 0, 0.8),
-    this.padding = EdgeInsets.zero,
+    this.modal,
+    this.surfaceClip,
+    this.borderRadius,
+    this.barrierColor,
+    this.padding,
     this.fadeAnimation,
     required this.child,
   });
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<ModalBackdropTheme>(context);
+    final modal = styleValue(
+        widgetValue: this.modal,
+        themeValue: compTheme?.modal,
+        defaultValue: true);
+    final surfaceClip = styleValue(
+        widgetValue: this.surfaceClip,
+        themeValue: compTheme?.surfaceClip,
+        defaultValue: true);
+    final borderRadius = styleValue(
+        widgetValue: this.borderRadius,
+        themeValue: compTheme?.borderRadius,
+        defaultValue: BorderRadius.zero);
+    final padding = styleValue(
+        widgetValue: this.padding,
+        themeValue: compTheme?.padding,
+        defaultValue: EdgeInsets.zero);
+    final barrierColor = styleValue(
+        widgetValue: this.barrierColor,
+        themeValue: compTheme?.barrierColor,
+        defaultValue: const Color.fromRGBO(0, 0, 0, 0.8));
     if (!modal) {
       return child;
     }

--- a/lib/src/components/overlay/hover_card.dart
+++ b/lib/src/components/overlay/hover_card.dart
@@ -1,26 +1,87 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class HoverCardTheme {
+  final Duration? debounce;
+  final Duration? wait;
+  final AlignmentGeometry? popoverAlignment;
+  final AlignmentGeometry? anchorAlignment;
+  final Offset? popoverOffset;
+  final HitTestBehavior? behavior;
+
+  const HoverCardTheme({
+    this.debounce,
+    this.wait,
+    this.popoverAlignment,
+    this.anchorAlignment,
+    this.popoverOffset,
+    this.behavior,
+  });
+
+  HoverCardTheme copyWith({
+    ValueGetter<Duration?>? debounce,
+    ValueGetter<Duration?>? wait,
+    ValueGetter<AlignmentGeometry?>? popoverAlignment,
+    ValueGetter<AlignmentGeometry?>? anchorAlignment,
+    ValueGetter<Offset?>? popoverOffset,
+    ValueGetter<HitTestBehavior?>? behavior,
+  }) {
+    return HoverCardTheme(
+      debounce: debounce == null ? this.debounce : debounce(),
+      wait: wait == null ? this.wait : wait(),
+      popoverAlignment: popoverAlignment == null
+          ? this.popoverAlignment
+          : popoverAlignment(),
+      anchorAlignment:
+          anchorAlignment == null ? this.anchorAlignment : anchorAlignment(),
+      popoverOffset:
+          popoverOffset == null ? this.popoverOffset : popoverOffset(),
+      behavior: behavior == null ? this.behavior : behavior(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is HoverCardTheme &&
+        other.debounce == debounce &&
+        other.wait == wait &&
+        other.popoverAlignment == popoverAlignment &&
+        other.anchorAlignment == anchorAlignment &&
+        other.popoverOffset == popoverOffset &&
+        other.behavior == behavior;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        debounce,
+        wait,
+        popoverAlignment,
+        anchorAlignment,
+        popoverOffset,
+        behavior,
+      );
+}
+
 class HoverCard extends StatefulWidget {
   final Widget child;
-  final Duration debounce;
-  final Duration wait;
+  final Duration? debounce;
+  final Duration? wait;
   final WidgetBuilder hoverBuilder;
-  final AlignmentGeometry popoverAlignment;
+  final AlignmentGeometry? popoverAlignment;
   final AlignmentGeometry? anchorAlignment;
-  final Offset popoverOffset;
-  final HitTestBehavior behavior;
+  final Offset? popoverOffset;
+  final HitTestBehavior? behavior;
   final PopoverController? controller;
   final OverlayHandler? handler;
   const HoverCard({
     super.key,
     required this.child,
     required this.hoverBuilder,
-    this.debounce = const Duration(milliseconds: 500),
-    this.wait = const Duration(milliseconds: 500),
-    this.popoverAlignment = Alignment.topCenter,
+    this.debounce,
+    this.wait,
+    this.popoverAlignment,
     this.anchorAlignment,
-    this.popoverOffset = const Offset(0, 8),
-    this.behavior = HitTestBehavior.deferToChild,
+    this.popoverOffset,
+    this.behavior,
     this.controller,
     this.handler,
   });
@@ -58,20 +119,49 @@ class _HoverCardState extends State<HoverCard> {
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<HoverCardTheme>(context);
+    final debounce = styleValue(
+        widgetValue: widget.debounce,
+        themeValue: compTheme?.debounce,
+        defaultValue: const Duration(milliseconds: 500));
+    final wait = styleValue(
+        widgetValue: widget.wait,
+        themeValue: compTheme?.wait,
+        defaultValue: const Duration(milliseconds: 500));
+    final popoverAlignment = styleValue(
+        widgetValue: widget.popoverAlignment,
+        themeValue: compTheme?.popoverAlignment,
+        defaultValue: Alignment.topCenter);
+    final anchorAlignment = styleValue(
+        widgetValue: widget.anchorAlignment,
+        themeValue: compTheme?.anchorAlignment);
+    final popoverOffset = styleValue(
+        widgetValue: widget.popoverOffset,
+        themeValue: compTheme?.popoverOffset,
+        defaultValue: const Offset(0, 8));
+    final behavior = styleValue(
+        widgetValue: widget.behavior,
+        themeValue: compTheme?.behavior,
+        defaultValue: HitTestBehavior.deferToChild);
     return MouseRegion(
+      behavior: behavior,
       onEnter: (_) {
         int count = ++_hoverCount;
-        Future.delayed(widget.wait, () {
+        Future.delayed(wait, () {
           if (count == _hoverCount &&
               !_controller.hasOpenPopover &&
               context.mounted) {
-            _showPopover(context);
+            _showPopover(context,
+                alignment: popoverAlignment,
+                anchorAlignment: anchorAlignment,
+                offset: popoverOffset,
+                debounce: debounce);
           }
         });
       },
       onExit: (_) {
         int count = ++_hoverCount;
-        Future.delayed(widget.debounce, () {
+        Future.delayed(debounce, () {
           if (count == _hoverCount) {
             _controller.close();
           }
@@ -80,14 +170,22 @@ class _HoverCardState extends State<HoverCard> {
       child: GestureDetector(
         onLongPress: () {
           // open popover on long press
-          _showPopover(context);
+          _showPopover(context,
+              alignment: popoverAlignment,
+              anchorAlignment: anchorAlignment,
+              offset: popoverOffset,
+              debounce: debounce);
         },
         child: widget.child,
       ),
     );
   }
 
-  void _showPopover(BuildContext context) {
+  void _showPopover(BuildContext context,
+      {required AlignmentGeometry alignment,
+      AlignmentGeometry? anchorAlignment,
+      required Offset offset,
+      required Duration debounce}) {
     OverlayHandler? handler = widget.handler;
     if (handler == null) {
       final overlayManager = OverlayManager.of(context);
@@ -103,7 +201,7 @@ class _HoverCardState extends State<HoverCard> {
           },
           onExit: (_) {
             int count = ++_hoverCount;
-            Future.delayed(widget.debounce, () {
+            Future.delayed(debounce, () {
               if (count == _hoverCount) {
                 _controller.close();
               }
@@ -112,9 +210,9 @@ class _HoverCardState extends State<HoverCard> {
           child: widget.hoverBuilder(context),
         );
       },
-      alignment: widget.popoverAlignment,
-      anchorAlignment: widget.anchorAlignment,
-      offset: widget.popoverOffset,
+      alignment: alignment,
+      anchorAlignment: anchorAlignment,
+      offset: offset,
       handler: handler,
     );
   }

--- a/lib/src/components/overlay/tooltip.dart
+++ b/lib/src/components/overlay/tooltip.dart
@@ -1,16 +1,84 @@
+import 'package:flutter/foundation.dart';
 import 'package:shadcn_flutter/src/components/control/hover.dart';
 
 import '../../../shadcn_flutter.dart';
+
+/// Theme configuration for [TooltipContainer].
+class TooltipTheme {
+  /// Opacity applied to the tooltip surface color.
+  final double? surfaceOpacity;
+
+  /// Blur amount for the tooltip surface.
+  final double? surfaceBlur;
+
+  /// Padding around the tooltip content.
+  final EdgeInsetsGeometry? padding;
+
+  /// Background color of the tooltip.
+  final Color? backgroundColor;
+
+  /// Border radius of the tooltip container.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Creates a [TooltipTheme].
+  const TooltipTheme({
+    this.surfaceOpacity,
+    this.surfaceBlur,
+    this.padding,
+    this.backgroundColor,
+    this.borderRadius,
+  });
+
+  /// Creates a copy of this theme but with the given fields replaced.
+  TooltipTheme copyWith({
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+  }) {
+    return TooltipTheme(
+      surfaceOpacity:
+          surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
+      surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+      padding: padding == null ? this.padding : padding(),
+      backgroundColor:
+          backgroundColor == null ? this.backgroundColor : backgroundColor(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TooltipTheme &&
+        other.surfaceOpacity == surfaceOpacity &&
+        other.surfaceBlur == surfaceBlur &&
+        other.padding == padding &&
+        other.backgroundColor == backgroundColor &&
+        other.borderRadius == borderRadius;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      surfaceOpacity, surfaceBlur, padding, backgroundColor, borderRadius);
+}
 
 class TooltipContainer extends StatelessWidget {
   final Widget child;
   final double? surfaceOpacity;
   final double? surfaceBlur;
+  final EdgeInsetsGeometry? padding;
+  final Color? backgroundColor;
+  final BorderRadiusGeometry? borderRadius;
 
   const TooltipContainer({
     super.key,
     this.surfaceOpacity,
     this.surfaceBlur,
+    this.padding,
+    this.backgroundColor,
+    this.borderRadius,
     required this.child,
   });
 
@@ -22,32 +90,39 @@ class TooltipContainer extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
-    var backgroundColor = theme.colorScheme.primary;
-    // var surfaceOpacity = this.surfaceOpacity ?? theme.surfaceOpacity;
-    // var surfaceBlur = this.surfaceBlur ?? theme.surfaceBlur;
-    // Do not use the default value of theme.surfaceOpacity and theme.surfaceBlur
-    // but still allow the user to set the value
-    var surfaceOpacity = this.surfaceOpacity;
-    var surfaceBlur = this.surfaceBlur;
+    final compTheme = ComponentTheme.maybeOf<TooltipTheme>(context);
+    Color backgroundColor = styleValue(
+        widgetValue: this.backgroundColor,
+        themeValue: compTheme?.backgroundColor,
+        defaultValue: theme.colorScheme.primary);
+    var surfaceOpacity = this.surfaceOpacity ?? compTheme?.surfaceOpacity;
+    var surfaceBlur = this.surfaceBlur ?? compTheme?.surfaceBlur;
     if (surfaceOpacity != null) {
       backgroundColor = backgroundColor.scaleAlpha(surfaceOpacity);
     }
+    final padding = styleValue(
+            widgetValue: this.padding,
+            themeValue: compTheme?.padding,
+            defaultValue:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 6))
+        .resolve(Directionality.of(context)) *
+        scaling;
+    final borderRadius = styleValue(
+        widgetValue: this.borderRadius,
+        themeValue: compTheme?.borderRadius,
+        defaultValue: BorderRadius.circular(theme.radiusSm));
     Widget animatedContainer = Container(
-      padding: const EdgeInsets.symmetric(
-            horizontal: 12,
-            vertical: 6,
-          ) *
-          scaling,
+      padding: padding,
       decoration: BoxDecoration(
         color: backgroundColor,
-        borderRadius: BorderRadius.circular(theme.radiusSm),
+        borderRadius: borderRadius,
       ),
       child: child.xSmall().primaryForeground(),
     );
     if (surfaceBlur != null && surfaceBlur > 0) {
       animatedContainer = SurfaceBlur(
         surfaceBlur: surfaceBlur,
-        borderRadius: BorderRadius.circular(theme.radiusSm),
+        borderRadius: borderRadius,
         child: animatedContainer,
       );
     }

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,111 @@
+# ComponentTheme Implementation Checklist
+
+The following components still need `ComponentTheme` implementation.
+
+## display
+- [x] avatar
+- [x] badge
+- [ ] calendar
+- [ ] carousel
+- [x] chip
+- [x] circular_progress_indicator
+- [x] code_snippet
+- [x] divider
+- [x] dot_indicator
+- [x] fade_scroll
+- [x] keyboard_shortcut
+- [x] linear_progress_indicator
+- [x] number_ticker
+- [ ] progress
+- [x] skeleton
+- [ ] spinner
+
+## form
+- [ ] autocomplete
+- [x] checkbox
+- [ ] chip_input
+- [ ] color_picker
+- [ ] control
+- [ ] date_picker
+- [ ] file_input
+- [ ] file_picker
+- [ ] form
+- [ ] form_field
+- [ ] formatted_input
+- [ ] formatter
+- [ ] image
+- [ ] input
+- [ ] input_otp
+- [ ] item_picker
+- [ ] multiple_choice
+- [ ] number_input
+- [ ] object_input
+- [ ] phone_input
+- [ ] radio_group
+- [ ] select
+- [ ] slider
+- [ ] sortable
+- [x] star_rating
+- [x] switch
+- [ ] text_area
+- [ ] text_field
+- [ ] time_picker
+- [ ] validated
+
+## layout
+- [ ] accordion
+- [x] alert
+- [x] basic
+- [x] breadcrumb
+- [x] card
+- [x] card_image
+- [ ] collapsible
+- [x] dialog/alert_dialog
+- [x] focus_outline
+- [ ] group
+- [x] hidden
+- [ ] media_query
+- [x] outlined_container
+- [ ] overflow_marquee
+- [ ] resizable
+- [ ] scaffold
+- [ ] scrollable_client
+- [ ] sortable
+- [x] stage_container
+- [ ] stepper
+- [ ] steps
+- [ ] table
+- [ ] timeline
+- [ ] tree
+- [ ] window
+
+## menu
+- [ ] context_menu
+- [ ] dropdown_menu
+- [ ] menu
+- [ ] menubar
+- [ ] navigation_menu
+- [x] popup
+
+## navigation
+- [ ] navigation_bar
+- [x] pagination
+- [ ] tabs/tab_container
+- [x] tabs/tab_list
+- [ ] tabs/tab_pane
+- [x] tabs/tabs
+
+## overlay
+- [x] dialog
+- [ ] drawer
+- [x] hover_card
+- [ ] overlay
+- [ ] popover
+- [ ] refresh_trigger
+- [ ] swiper
+- [ ] toast
+- [x] tooltip
+
+## text
+- [ ] selectable
+- [ ] text


### PR DESCRIPTION
## Summary
- add FocusOutlineTheme to customize outline color, width, align, radius, and border radius
- introduce StageContainerTheme providing breakpoint and padding defaults for responsive layouts
- implement OutlinedContainerTheme for themable background, border, radius, padding, and blur
- create TabsTheme to configure tab padding, container padding, background, and border radius
- add TabListTheme allowing indicator and border styling to be themed
- introduce DotIndicatorTheme and wire DotIndicator, ActiveDotItem, and InactiveDotItem into ComponentTheme for spacing, sizing, and colors
- add FadeScrollTheme to configure offsets and gradients for fading scroll edges
- create KeyboardShortcutTheme and apply to KeyboardDisplay and KeyboardKeyDisplay for spacing, key padding, and shadows
- add TooltipTheme for customizing tooltip container background, padding, border radius, and surface effects
- implement ScrollbarTheme with color, thickness, and radius defaults merged via ComponentTheme
- add CircularProgressIndicatorTheme for controlling color, background, size, and stroke width
- wire Divider into ComponentTheme via DividerTheme for color, thickness, height, indents, and padding
- introduce AvatarTheme for size, border radius, background, badge alignment, gap, and text style defaults
- add CardTheme to customize padding, fill color, borders, shadows, and surface effects across Card and SurfaceCard
- introduce ChipTheme to supply default button style and padding for Chip and ChipButton
- create NumberTickerTheme for animation duration, curve, and text style
- implement AlertTheme to configure padding, background, and border color for alerts
- add CodeSnippetTheme to theme code block background, border, and padding
- add BadgeTheme to style badge variants with ComponentTheme support
- implement BreadcrumbTheme for themable separators and padding
- create HiddenTheme to customize animation direction, duration, and size retention
- add LinearProgressIndicatorTheme for configurable colors, height, border radius, sparks, and animation toggles
- introduce SkeletonTheme to tune pulse effect colors, duration, and switch animation
- add CheckboxTheme for checkbox sizing, spacing, colors, and border radius
- introduce SwitchTheme to theme track colors, thumb color, gap, and border radius
- create StarRatingTheme for star colors, size, and spacing
- implement PaginationTheme to control pagination gaps and label visibility
- add MenuPopupTheme for customizable surface styling, padding, and colors
- add BasicTheme to provide alignment, spacing, and padding defaults for Basic and BasicLayout
- introduce CardImageTheme to configure layout direction, scaling, colors, and gap for CardImage
- create HoverCardTheme and wire HoverCard to merge debounce, wait, alignment, offset, and behavior values from ComponentTheme
- add HoverTheme so HoverActivity and Hover can pull debounce, wait, duration, and hit-test settings from the theme
- implement ModalBackdropTheme enabling theming of radius, padding, barrier color, and surface clipping
- add ComponentTheme implementation TODO checklist covering display, form, layout, menu, navigation, overlay, and text components
- update ComponentTheme checklist to mark implemented components as completed

## Testing
- `apt-get update` *(W: Failed to fetch https://mise.jdx.dev/deb/... Forbidden; some index files failed to download)*
- `apt-get install -y dart` *(E: Unable to locate package dart)*
- `dart format todo.md` *(bash: command not found: dart)*
- `dart analyze` *(bash: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_b_68987d94578c8325ad89340de44f209b