### PR TITLE
feat(theme): add component themes and clean up utilities

### DIFF
--- a/lib/src/components/form/form_field.dart
+++ b/lib/src/components/form/form_field.dart
@@ -19,9 +19,9 @@ class ObjectFormField<T> extends StatefulWidget {
   final AlignmentGeometry? popoverAnchorAlignment;
   final EdgeInsetsGeometry? popoverPadding;
   final Widget? dialogTitle;
-  final ButtonSize size;
-  final ButtonDensity density;
-  final ButtonShape shape;
+  final ButtonSize? size;
+  final ButtonDensity? density;
+  final ButtonShape? shape;
   final List<Widget> Function(
       BuildContext context, ObjectFormHandler<T> handler)? dialogActions;
   final bool? enabled;
@@ -41,9 +41,9 @@ class ObjectFormField<T> extends StatefulWidget {
     this.popoverAnchorAlignment,
     this.popoverPadding,
     this.dialogTitle,
-    this.size = ButtonSize.normal,
-    this.density = ButtonDensity.normal,
-    this.shape = ButtonShape.rectangle,
+    this.size,
+    this.density,
+    this.shape,
     this.dialogActions,
     this.enabled,
     this.decorate = true,
@@ -167,12 +167,15 @@ class ObjectFormFieldState<T> extends State<ObjectFormField<T>>
 
   @override
   Widget build(BuildContext context) {
+    final size = widget.size ?? ButtonSize.normal;
+    final density = widget.density ?? ButtonDensity.normal;
+    final shape = widget.shape ?? ButtonShape.rectangle;
     return OutlineButton(
       trailing: widget.trailing?.iconMutedForeground().iconSmall(),
       leading: widget.leading?.iconMutedForeground().iconSmall(),
-      size: widget.size,
-      density: widget.density,
-      shape: widget.shape,
+      size: size,
+      density: density,
+      shape: shape,
       onPressed: widget.onChanged == null ? null : prompt,
       enabled: enabled,
       child: this.value == null

--- a/lib/src/components/form/formatted_input.dart
+++ b/lib/src/components/form/formatted_input.dart
@@ -4,6 +4,34 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class FormattedInputTheme {
+  final double? height;
+  final EdgeInsetsGeometry? padding;
+
+  const FormattedInputTheme({this.height, this.padding});
+
+  FormattedInputTheme copyWith({
+    ValueGetter<double?>? height,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+  }) {
+    return FormattedInputTheme(
+      height: height == null ? this.height : height(),
+      padding: padding == null ? this.padding : padding(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FormattedInputTheme &&
+        other.height == height &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(height, padding);
+}
+
 abstract class InputPart implements FormattedValuePart {
   const factory InputPart.static(String text) = StaticPart;
   const factory InputPart.editable({
@@ -562,9 +590,10 @@ class _FormattedInputState extends State<FormattedInput> {
         }
       }
     }
+    final compTheme = ComponentTheme.maybeOf<FormattedInputTheme>(context);
     return SizedBox(
-      height: kTextFieldHeight *
-          theme.scaling, // 32 (textfield height) + 2 (border)
+      height:
+          (compTheme?.height ?? kTextFieldHeight) * theme.scaling, // 32 + 2
       child: TextFieldTapRegion(
         child: Focus(
           onFocusChange: (hasFocus) {
@@ -576,9 +605,10 @@ class _FormattedInputState extends State<FormattedInput> {
             borderRadius: theme.borderRadiusMd,
             borderColor:
                 _hasFocus ? theme.colorScheme.ring : theme.colorScheme.border,
-            padding: EdgeInsets.symmetric(
-              horizontal: 6 * theme.scaling,
-            ),
+            padding: compTheme?.padding ??
+                EdgeInsets.symmetric(
+                  horizontal: 6 * theme.scaling,
+                ),
             child: Form(
               controller: _controller,
               child: FocusTraversalGroup(

--- a/lib/src/components/form/input_otp.dart
+++ b/lib/src/components/form/input_otp.dart
@@ -2,13 +2,42 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class InputOTPTheme {
+  final double? spacing;
+  final double? height;
+
+  const InputOTPTheme({this.spacing, this.height});
+
+  InputOTPTheme copyWith({
+    ValueGetter<double?>? spacing,
+    ValueGetter<double?>? height,
+  }) {
+    return InputOTPTheme(
+      spacing: spacing == null ? this.spacing : spacing(),
+      height: height == null ? this.height : height(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is InputOTPTheme &&
+        other.spacing == spacing &&
+        other.height == height;
+  }
+
+  @override
+  int get hashCode => Object.hash(spacing, height);
+}
+
 class _InputOTPSpacing extends StatelessWidget {
   const _InputOTPSpacing();
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return SizedBox(width: theme.scaling * 8);
+    final compTheme = ComponentTheme.maybeOf<InputOTPTheme>(context);
+    return SizedBox(width: compTheme?.spacing ?? theme.scaling * 8);
   }
 }
 
@@ -630,8 +659,9 @@ class _InputOTPState extends State<InputOTP>
             )));
       }
     }
+    final compTheme = ComponentTheme.maybeOf<InputOTPTheme>(context);
     return SizedBox(
-      height: theme.scaling * 36,
+      height: compTheme?.height ?? theme.scaling * 36,
       child: IntrinsicWidth(
         child: Row(
           children: [

--- a/lib/src/components/form/item_picker.dart
+++ b/lib/src/components/form/item_picker.dart
@@ -5,10 +5,10 @@ class ItemPicker<T> extends StatelessWidget {
   final ItemPickerBuilder<T> builder;
   final T? value;
   final ValueChanged<T?>? onChanged;
-  final ItemPickerLayout layout;
+  final ItemPickerLayout? layout;
   final Widget? placeholder;
   final Widget? title;
-  final PromptMode mode;
+  final PromptMode? mode;
   final BoxConstraints? constraints;
   const ItemPicker({
     super.key,
@@ -16,15 +16,18 @@ class ItemPicker<T> extends StatelessWidget {
     required this.builder,
     this.value,
     this.onChanged,
-    this.layout = ItemPickerLayout.grid,
+    this.layout,
     this.placeholder,
     this.title,
-    this.mode = PromptMode.dialog,
+    this.mode,
     this.constraints,
   });
 
   @override
   Widget build(BuildContext context) {
+    final layout = this.layout ?? ItemPickerLayout.grid;
+    final mode = this.mode ?? PromptMode.dialog;
+    final constraints = this.constraints;
     return ObjectFormField(
         value: value,
         placeholder: placeholder ?? const SizedBox.shrink(),

--- a/lib/src/components/form/multiple_choice.dart
+++ b/lib/src/components/form/multiple_choice.dart
@@ -1,5 +1,32 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme data for [MultipleChoice] and [MultipleAnswer].
+class MultipleChoiceTheme {
+  /// Whether selections can be unselected.
+  final bool? allowUnselect;
+
+  /// Creates a [MultipleChoiceTheme].
+  const MultipleChoiceTheme({this.allowUnselect});
+
+  /// Returns a copy of this theme with the given fields replaced by the
+  /// non-null parameters.
+  MultipleChoiceTheme copyWith({ValueGetter<bool?>? allowUnselect}) {
+    return MultipleChoiceTheme(
+      allowUnselect: allowUnselect == null ? this.allowUnselect : allowUnselect(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is MultipleChoiceTheme && other.allowUnselect == allowUnselect;
+
+  @override
+  int get hashCode => allowUnselect.hashCode;
+
+  @override
+  String toString() => 'MultipleChoiceTheme(allowUnselect: $allowUnselect)';
+}
+
 mixin Choice<T> {
   static void choose<T>(BuildContext context, T item) {
     Data.of<Choice<T>>(context).selectItem(item);
@@ -33,7 +60,7 @@ class ControlledMultipleAnswer<T> extends StatelessWidget
   final ValueChanged<Iterable<T>?>? onChanged;
   @override
   final bool enabled;
-  final bool allowUnselect;
+  final bool? allowUnselect;
   final Widget child;
 
   const ControlledMultipleAnswer({
@@ -42,7 +69,7 @@ class ControlledMultipleAnswer<T> extends StatelessWidget
     this.onChanged,
     this.initialValue,
     this.enabled = true,
-    this.allowUnselect = true,
+    this.allowUnselect,
     required this.child,
   });
 
@@ -76,7 +103,7 @@ class ControlledMultipleChoice<T> extends StatelessWidget
   final ValueChanged<T?>? onChanged;
   @override
   final bool enabled;
-  final bool allowUnselect;
+  final bool? allowUnselect;
   final Widget child;
 
   const ControlledMultipleChoice({
@@ -85,7 +112,7 @@ class ControlledMultipleChoice<T> extends StatelessWidget
     this.onChanged,
     this.initialValue,
     this.enabled = true,
-    this.allowUnselect = false,
+    this.allowUnselect,
     required this.child,
   });
 
@@ -114,7 +141,7 @@ class MultipleChoice<T> extends StatefulWidget {
   final T? value;
   final ValueChanged<T?>? onChanged;
   final bool? enabled;
-  final bool allowUnselect;
+  final bool? allowUnselect;
 
   const MultipleChoice({
     super.key,
@@ -122,7 +149,7 @@ class MultipleChoice<T> extends StatefulWidget {
     this.value,
     this.onChanged,
     this.enabled,
-    this.allowUnselect = false,
+    this.allowUnselect,
   });
 
   @override
@@ -168,7 +195,7 @@ class _MultipleChoiceState<T> extends State<MultipleChoice<T>>
     }
     if (widget.onChanged != null) {
       if (widget.value == item) {
-        if (widget.allowUnselect) {
+        if (_allowUnselect) {
           widget.onChanged?.call(null);
         }
       } else {
@@ -185,6 +212,11 @@ class _MultipleChoiceState<T> extends State<MultipleChoice<T>>
     }
     return [value];
   }
+
+  bool get _allowUnselect {
+    final theme = ComponentTheme.maybeOf<MultipleChoiceTheme>(context);
+    return widget.allowUnselect ?? theme?.allowUnselect ?? false;
+  }
 }
 
 class MultipleAnswer<T> extends StatefulWidget {
@@ -200,7 +232,7 @@ class MultipleAnswer<T> extends StatefulWidget {
     this.value,
     this.onChanged,
     this.enabled,
-    this.allowUnselect = true,
+    this.allowUnselect,
   });
 
   @override
@@ -240,7 +272,7 @@ class _MultipleAnswerState<T> extends State<MultipleAnswer<T>>
     if (value == null) {
       widget.onChanged?.call([item]);
     } else if (value.contains(item)) {
-      if (widget.allowUnselect) {
+      if (_allowUnselect) {
         widget.onChanged?.call(value.where((e) => e != item));
       }
     } else {
@@ -256,5 +288,10 @@ class _MultipleAnswerState<T> extends State<MultipleAnswer<T>>
   @override
   void didReplaceFormValue(Iterable<T>? value) {
     widget.onChanged?.call(value);
+  }
+
+  bool get _allowUnselect {
+    final theme = ComponentTheme.maybeOf<MultipleChoiceTheme>(context);
+    return widget.allowUnselect ?? theme?.allowUnselect ?? true;
   }
 }

--- a/lib/src/components/form/number_input.dart
+++ b/lib/src/components/form/number_input.dart
@@ -2,6 +2,34 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class NumberInputTheme {
+  final AbstractButtonStyle? buttonStyle;
+  final EdgeInsetsGeometry? padding;
+
+  const NumberInputTheme({this.buttonStyle, this.padding});
+
+  NumberInputTheme copyWith({
+    ValueGetter<AbstractButtonStyle?>? buttonStyle,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+  }) {
+    return NumberInputTheme(
+      buttonStyle: buttonStyle == null ? this.buttonStyle : buttonStyle(),
+      padding: padding == null ? this.padding : padding(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NumberInputTheme &&
+        other.buttonStyle == buttonStyle &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(buttonStyle, padding);
+}
+
 @Deprecated('Use TextField with InputFeature.spinner() instead.')
 class NumberInput extends StatefulWidget {
   static final _decimalFormatter = FilteringTextInputFormatter.allow(
@@ -99,7 +127,9 @@ class _NumberInputState extends State<NumberInput>
   }
 
   AbstractButtonStyle get _buttonStyle {
+    final compTheme = ComponentTheme.maybeOf<NumberInputTheme>(context);
     return widget.buttonStyle ??
+        compTheme?.buttonStyle ??
         const ButtonStyle.text(
           density: ButtonDensity.compact,
           size: ButtonSize.small,
@@ -252,6 +282,7 @@ class _NumberInputState extends State<NumberInput>
 
   Widget buildTextField(BuildContext context, ThemeData theme) {
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<NumberInputTheme>(context);
     return ConstrainedBox(
       constraints: BoxConstraints(
         minWidth: 50 * scaling,
@@ -268,6 +299,7 @@ class _NumberInputState extends State<NumberInput>
           ],
         ),
         padding: widget.padding ??
+            compTheme?.padding ??
             EdgeInsetsDirectional.only(
               start: 10 * scaling,
             ),

--- a/lib/src/components/form/slider.dart
+++ b/lib/src/components/form/slider.dart
@@ -119,6 +119,108 @@ class SliderValue {
   }
 }
 
+/// Theme for [Slider].
+class SliderTheme {
+  /// Height of the track.
+  final double? trackHeight;
+
+  /// Color of the inactive track.
+  final Color? trackColor;
+
+  /// Color of the active portion of the track.
+  final Color? valueColor;
+
+  /// Color of the inactive track when disabled.
+  final Color? disabledTrackColor;
+
+  /// Color of the active track when disabled.
+  final Color? disabledValueColor;
+
+  /// Background color of the thumb.
+  final Color? thumbColor;
+
+  /// Border color of the thumb.
+  final Color? thumbBorderColor;
+
+  /// Border color of the thumb when focused.
+  final Color? thumbFocusedBorderColor;
+
+  /// Size of the thumb.
+  final double? thumbSize;
+
+  /// Creates a [SliderTheme].
+  const SliderTheme({
+    this.trackHeight,
+    this.trackColor,
+    this.valueColor,
+    this.disabledTrackColor,
+    this.disabledValueColor,
+    this.thumbColor,
+    this.thumbBorderColor,
+    this.thumbFocusedBorderColor,
+    this.thumbSize,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  SliderTheme copyWith({
+    ValueGetter<double?>? trackHeight,
+    ValueGetter<Color?>? trackColor,
+    ValueGetter<Color?>? valueColor,
+    ValueGetter<Color?>? disabledTrackColor,
+    ValueGetter<Color?>? disabledValueColor,
+    ValueGetter<Color?>? thumbColor,
+    ValueGetter<Color?>? thumbBorderColor,
+    ValueGetter<Color?>? thumbFocusedBorderColor,
+    ValueGetter<double?>? thumbSize,
+  }) {
+    return SliderTheme(
+      trackHeight: trackHeight == null ? this.trackHeight : trackHeight(),
+      trackColor: trackColor == null ? this.trackColor : trackColor(),
+      valueColor: valueColor == null ? this.valueColor : valueColor(),
+      disabledTrackColor: disabledTrackColor == null
+          ? this.disabledTrackColor
+          : disabledTrackColor(),
+      disabledValueColor: disabledValueColor == null
+          ? this.disabledValueColor
+          : disabledValueColor(),
+      thumbColor: thumbColor == null ? this.thumbColor : thumbColor(),
+      thumbBorderColor:
+          thumbBorderColor == null ? this.thumbBorderColor : thumbBorderColor(),
+      thumbFocusedBorderColor: thumbFocusedBorderColor == null
+          ? this.thumbFocusedBorderColor
+          : thumbFocusedBorderColor(),
+      thumbSize: thumbSize == null ? this.thumbSize : thumbSize(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SliderTheme &&
+        other.trackHeight == trackHeight &&
+        other.trackColor == trackColor &&
+        other.valueColor == valueColor &&
+        other.disabledTrackColor == disabledTrackColor &&
+        other.disabledValueColor == disabledValueColor &&
+        other.thumbColor == thumbColor &&
+        other.thumbBorderColor == thumbBorderColor &&
+        other.thumbFocusedBorderColor == thumbFocusedBorderColor &&
+        other.thumbSize == thumbSize;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      trackHeight,
+      trackColor,
+      valueColor,
+      disabledTrackColor,
+      disabledValueColor,
+      thumbColor,
+      thumbBorderColor,
+      thumbFocusedBorderColor,
+      thumbSize);
+}
+
 class IncreaseSliderValue extends Intent {
   const IncreaseSliderValue();
 }
@@ -626,6 +728,7 @@ class _SliderState extends State<Slider>
       BuildContext context, BoxConstraints constraints, ThemeData theme) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<SliderTheme>(context);
     var value = widget.value;
     var start = value.start;
     var end = value.end;
@@ -664,11 +767,12 @@ class _SliderState extends State<Slider>
             bottom: 0,
             child: Center(
               child: Container(
-                height: 6 * scaling,
+                height: (compTheme?.trackHeight ?? 6) * scaling,
                 decoration: BoxDecoration(
                   color: enabled
-                      ? theme.colorScheme.primary
-                      : theme.colorScheme.mutedForeground,
+                      ? (compTheme?.valueColor ?? theme.colorScheme.primary)
+                      : (compTheme?.disabledValueColor ??
+                          theme.colorScheme.mutedForeground),
                   borderRadius: BorderRadius.circular(theme.radiusSm),
                 ),
               ),
@@ -681,6 +785,7 @@ class _SliderState extends State<Slider>
       BuildContext context, BoxConstraints constraints, ThemeData theme) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<SliderTheme>(context);
     return Positioned(
       left: 0,
       right: 0,
@@ -688,11 +793,12 @@ class _SliderState extends State<Slider>
       bottom: 0,
       child: Center(
         child: Container(
-          height: 6 * scaling,
+          height: (compTheme?.trackHeight ?? 6) * scaling,
           decoration: BoxDecoration(
             color: enabled
-                ? theme.colorScheme.primary.scaleAlpha(0.2)
-                : theme.colorScheme.muted,
+                ? (compTheme?.trackColor ??
+                    theme.colorScheme.primary.scaleAlpha(0.2))
+                : (compTheme?.disabledTrackColor ?? theme.colorScheme.muted),
             borderRadius: BorderRadius.circular(theme.radiusSm),
           ),
         ),
@@ -711,6 +817,7 @@ class _SliderState extends State<Slider>
       VoidCallback onDecrease) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<SliderTheme>(context);
     if (widget.divisions != null) {
       value = (value * widget.divisions!).round() / widget.divisions!;
     }
@@ -754,25 +861,27 @@ class _SliderState extends State<Slider>
                 ),
               },
               child: Container(
-                width: 16 * scaling,
-                height: 16 * scaling,
+                width: (compTheme?.thumbSize ?? 16) * scaling,
+                height: (compTheme?.thumbSize ?? 16) * scaling,
                 decoration: BoxDecoration(
-                  color: theme.colorScheme.background,
+                  color: compTheme?.thumbColor ?? theme.colorScheme.background,
                   shape: BoxShape.circle,
-                  border: focusing
-                      ? Border.all(
-                          color: enabled
-                              ? theme.colorScheme.primary
-                              : theme.colorScheme.mutedForeground,
-                          width: 2 * scaling,
-                          strokeAlign: BorderSide.strokeAlignOutside,
-                        )
-                      : Border.all(
-                          color: enabled
-                              ? theme.colorScheme.primary.scaleAlpha(0.5)
-                              : theme.colorScheme.mutedForeground,
-                          width: 1 * scaling,
-                        ),
+                  border: Border.all(
+                    color: focusing
+                        ? (enabled
+                            ? (compTheme?.thumbFocusedBorderColor ??
+                                theme.colorScheme.primary)
+                            : (compTheme?.disabledValueColor ??
+                                theme.colorScheme.mutedForeground))
+                        : (enabled
+                            ? (compTheme?.thumbBorderColor ??
+                                theme.colorScheme.primary.scaleAlpha(0.5))
+                            : (compTheme?.disabledValueColor ??
+                                theme.colorScheme.mutedForeground)),
+                    width: focusing ? 2 * scaling : 1 * scaling,
+                    strokeAlign:
+                        focusing ? BorderSide.strokeAlignOutside : null,
+                  ),
                 ),
               ),
             ),

--- a/lib/src/components/form/text_field.dart
+++ b/lib/src/components/form/text_field.dart
@@ -19,6 +19,47 @@ import '../../../shadcn_flutter.dart';
 import 'package:flutter/material.dart' as material;
 import 'package:flutter/cupertino.dart' as cupertino;
 
+class TextFieldTheme {
+  final bool? border;
+  final BorderRadiusGeometry? borderRadius;
+  final bool? filled;
+  final EdgeInsetsGeometry? padding;
+
+  const TextFieldTheme({
+    this.border,
+    this.borderRadius,
+    this.filled,
+    this.padding,
+  });
+
+  TextFieldTheme copyWith({
+    ValueGetter<bool?>? border,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+    ValueGetter<bool?>? filled,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+  }) {
+    return TextFieldTheme(
+      border: border == null ? this.border : border(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+      filled: filled == null ? this.filled : filled(),
+      padding: padding == null ? this.padding : padding(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TextFieldTheme &&
+        other.border == border &&
+        other.borderRadius == borderRadius &&
+        other.filled == filled &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(border, borderRadius, filled, padding);
+}
+
 export 'package:flutter/services.dart'
     show
         SmartDashesType,
@@ -1862,6 +1903,7 @@ class TextFieldState extends State<TextField>
     var widget = this.widget;
     super.build(context); // See AutomaticKeepAliveClientMixin.
     final ThemeData theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<TextFieldTheme>(context);
     assert(debugCheckHasDirectionality(context));
     final TextEditingController controller = effectiveController;
 
@@ -1927,11 +1969,15 @@ class TextFieldState extends State<TextField>
     // Use the default disabled color only if the box decoration was not set.
     final BoxDecoration effectiveDecoration = widget.decoration ??
         BoxDecoration(
-          borderRadius:
-              optionallyResolveBorderRadius(context, widget.borderRadius) ??
-                  BorderRadius.circular(theme.radiusMd),
-          color: widget.filled ? theme.colorScheme.muted : null,
-          border: widget.border
+          borderRadius: optionallyResolveBorderRadius(
+                context,
+                widget.borderRadius ?? compTheme?.borderRadius,
+              ) ??
+              BorderRadius.circular(theme.radiusMd),
+          color: (widget.filled ?? compTheme?.filled ?? false)
+              ? theme.colorScheme.muted
+              : null,
+          border: (widget.border ?? compTheme?.border ?? true)
               ? Border.all(
                   color: _effectiveFocusNode.hasFocus && widget.enabled
                       ? theme.colorScheme.ring
@@ -2095,6 +2141,7 @@ class TextFieldState extends State<TextField>
                       heightFactor: 1.0,
                       child: Padding(
                         padding: widget.padding ??
+                            compTheme?.padding ??
                             EdgeInsets.symmetric(
                               horizontal: 12 * scaling,
                               vertical: 8 * scaling,

--- a/lib/src/components/form/time_picker.dart
+++ b/lib/src/components/form/time_picker.dart
@@ -2,6 +2,75 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class TimePickerTheme {
+  final PromptMode? mode;
+  final AlignmentGeometry? popoverAlignment;
+  final AlignmentGeometry? popoverAnchorAlignment;
+  final EdgeInsetsGeometry? popoverPadding;
+  final bool? use24HourFormat;
+  final bool? showSeconds;
+  final Widget? dialogTitle;
+
+  const TimePickerTheme({
+    this.mode,
+    this.popoverAlignment,
+    this.popoverAnchorAlignment,
+    this.popoverPadding,
+    this.use24HourFormat,
+    this.showSeconds,
+    this.dialogTitle,
+  });
+
+  TimePickerTheme copyWith({
+    ValueGetter<PromptMode?>? mode,
+    ValueGetter<AlignmentGeometry?>? popoverAlignment,
+    ValueGetter<AlignmentGeometry?>? popoverAnchorAlignment,
+    ValueGetter<EdgeInsetsGeometry?>? popoverPadding,
+    ValueGetter<bool?>? use24HourFormat,
+    ValueGetter<bool?>? showSeconds,
+    ValueGetter<Widget?>? dialogTitle,
+  }) {
+    return TimePickerTheme(
+      mode: mode == null ? this.mode : mode(),
+      popoverAlignment:
+          popoverAlignment == null ? this.popoverAlignment : popoverAlignment(),
+      popoverAnchorAlignment: popoverAnchorAlignment == null
+          ? this.popoverAnchorAlignment
+          : popoverAnchorAlignment(),
+      popoverPadding:
+          popoverPadding == null ? this.popoverPadding : popoverPadding(),
+      use24HourFormat:
+          use24HourFormat == null ? this.use24HourFormat : use24HourFormat(),
+      showSeconds: showSeconds == null ? this.showSeconds : showSeconds(),
+      dialogTitle: dialogTitle == null ? this.dialogTitle : dialogTitle(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TimePickerTheme &&
+        other.mode == mode &&
+        other.popoverAlignment == popoverAlignment &&
+        other.popoverAnchorAlignment == popoverAnchorAlignment &&
+        other.popoverPadding == popoverPadding &&
+        other.use24HourFormat == use24HourFormat &&
+        other.showSeconds == showSeconds &&
+        other.dialogTitle == dialogTitle;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        mode,
+        popoverAlignment,
+        popoverAnchorAlignment,
+        popoverPadding,
+        use24HourFormat,
+        showSeconds,
+        dialogTitle,
+      );
+}
+
 class TimePickerController extends ValueNotifier<TimeOfDay?>
     with ComponentController<TimeOfDay?> {
   TimePickerController([super.value]);
@@ -100,19 +169,28 @@ class TimePicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     ShadcnLocalizations localizations = ShadcnLocalizations.of(context);
-    bool use24HourFormat =
-        this.use24HourFormat ?? MediaQuery.of(context).alwaysUse24HourFormat;
+    final compTheme = ComponentTheme.maybeOf<TimePickerTheme>(context);
+    bool use24HourFormat = this.use24HourFormat ??
+        compTheme?.use24HourFormat ??
+        MediaQuery.of(context).alwaysUse24HourFormat;
+    final bool showSeconds =
+        compTheme?.showSeconds ?? this.showSeconds;
     return ObjectFormField(
       value: value,
-      placeholder: placeholder ?? Text(localizations.placeholderTimePicker),
+      placeholder: placeholder ??
+          Text(localizations.placeholderTimePicker),
       onChanged: onChanged,
       builder: (context, value) {
         return Text(localizations.formatTimeOfDay(value,
             use24HourFormat: use24HourFormat, showSeconds: showSeconds));
       },
       enabled: enabled,
-      mode: mode,
-      dialogTitle: dialogTitle,
+      mode: compTheme?.mode ?? mode,
+      dialogTitle: dialogTitle ?? compTheme?.dialogTitle,
+      popoverAlignment: popoverAlignment ?? compTheme?.popoverAlignment,
+      popoverAnchorAlignment:
+          popoverAnchorAlignment ?? compTheme?.popoverAnchorAlignment,
+      popoverPadding: popoverPadding ?? compTheme?.popoverPadding,
       trailing: const Icon(Icons.access_time),
       editorBuilder: (context, handler) {
         return TimePickerDialog(

--- a/lib/src/components/layout/scaffold.dart
+++ b/lib/src/components/layout/scaffold.dart
@@ -4,6 +4,74 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme data for [Scaffold].
+class ScaffoldTheme {
+  /// Background color of the scaffold body.
+  final Color? backgroundColor;
+
+  /// Background color of the header section.
+  final Color? headerBackgroundColor;
+
+  /// Background color of the footer section.
+  final Color? footerBackgroundColor;
+
+  /// Whether to show loading sparks by default.
+  final bool? showLoadingSparks;
+
+  /// Whether the scaffold should resize for the onscreen keyboard.
+  final bool? resizeToAvoidBottomInset;
+
+  const ScaffoldTheme({
+    this.backgroundColor,
+    this.headerBackgroundColor,
+    this.footerBackgroundColor,
+    this.showLoadingSparks,
+    this.resizeToAvoidBottomInset,
+  });
+
+  ScaffoldTheme copyWith({
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<Color?>? headerBackgroundColor,
+    ValueGetter<Color?>? footerBackgroundColor,
+    ValueGetter<bool?>? showLoadingSparks,
+    ValueGetter<bool?>? resizeToAvoidBottomInset,
+  }) {
+    return ScaffoldTheme(
+      backgroundColor:
+          backgroundColor == null ? this.backgroundColor : backgroundColor(),
+      headerBackgroundColor: headerBackgroundColor == null
+          ? this.headerBackgroundColor
+          : headerBackgroundColor(),
+      footerBackgroundColor: footerBackgroundColor == null
+          ? this.footerBackgroundColor
+          : footerBackgroundColor(),
+      showLoadingSparks: showLoadingSparks == null
+          ? this.showLoadingSparks
+          : showLoadingSparks(),
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset == null
+          ? this.resizeToAvoidBottomInset
+          : resizeToAvoidBottomInset(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is ScaffoldTheme &&
+      other.backgroundColor == backgroundColor &&
+      other.headerBackgroundColor == headerBackgroundColor &&
+      other.footerBackgroundColor == footerBackgroundColor &&
+      other.showLoadingSparks == showLoadingSparks &&
+      other.resizeToAvoidBottomInset == resizeToAvoidBottomInset;
+
+  @override
+  int get hashCode => Object.hash(backgroundColor, headerBackgroundColor,
+      footerBackgroundColor, showLoadingSparks, resizeToAvoidBottomInset);
+
+  @override
+  String toString() =>
+      'ScaffoldTheme(background: $backgroundColor, header: $headerBackgroundColor, footer: $footerBackgroundColor, showLoadingSparks: $showLoadingSparks, resizeToAvoidBottomInset: $resizeToAvoidBottomInset)';
+}
+
 class Scaffold extends StatefulWidget {
   final List<Widget> headers;
   final List<Widget> footers;
@@ -16,7 +84,7 @@ class Scaffold extends StatefulWidget {
   final Color? headerBackgroundColor;
   final Color? footerBackgroundColor;
   final Color? backgroundColor;
-  final bool showLoadingSparks;
+  final bool? showLoadingSparks;
   final bool? resizeToAvoidBottomInset;
 
   const Scaffold({
@@ -31,7 +99,7 @@ class Scaffold extends StatefulWidget {
     this.backgroundColor,
     this.headerBackgroundColor,
     this.footerBackgroundColor,
-    this.showLoadingSparks = false,
+    this.showLoadingSparks,
     this.resizeToAvoidBottomInset,
   });
 
@@ -53,9 +121,10 @@ class ScaffoldBarData {
 
 class ScaffoldState extends State<Scaffold> {
   Widget buildHeader(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<ScaffoldTheme>(context);
     return RepaintBoundary(
       child: Container(
-        color: widget.headerBackgroundColor,
+        color: widget.headerBackgroundColor ?? compTheme?.headerBackgroundColor,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -100,7 +169,10 @@ class ScaffoldState extends State<Scaffold> {
                     ]),
               ],
             ),
-            if (widget.loadingProgress != null && widget.showLoadingSparks)
+            if (widget.loadingProgress != null &&
+                (widget.showLoadingSparks ??
+                    compTheme?.showLoadingSparks ??
+                    false))
               SizedBox(
                 // to make it float
                 height: 0,
@@ -129,11 +201,12 @@ class ScaffoldState extends State<Scaffold> {
   }
 
   Widget buildFooter(BuildContext context, EdgeInsets viewInsets) {
+    final compTheme = ComponentTheme.maybeOf<ScaffoldTheme>(context);
     return Offstage(
       offstage: viewInsets.bottom > 0,
       child: RepaintBoundary(
         child: Container(
-          color: widget.footerBackgroundColor,
+          color: widget.footerBackgroundColor ?? compTheme?.footerBackgroundColor,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
@@ -155,17 +228,22 @@ class ScaffoldState extends State<Scaffold> {
 
   Widget _buildContent(BuildContext context) {
     final theme = Theme.of(context);
+    final compTheme = ComponentTheme.maybeOf<ScaffoldTheme>(context);
     final viewInsets = MediaQuery.viewInsetsOf(context);
     return DrawerOverlay(
       child: Container(
-        color: widget.backgroundColor ?? theme.colorScheme.background,
+        color: widget.backgroundColor ??
+            compTheme?.backgroundColor ??
+            theme.colorScheme.background,
         child: _ScaffoldFlex(
           floatingHeader: widget.floatingHeader,
           floatingFooter: widget.floatingFooter,
           children: [
             buildHeader(context),
             LayoutBuilder(builder: (context, constraints) {
-              Widget child = (widget.resizeToAvoidBottomInset ?? true)
+              Widget child = (widget.resizeToAvoidBottomInset ??
+                      compTheme?.resizeToAvoidBottomInset ??
+                      true)
                   ? Container(
                       padding: EdgeInsets.only(
                         bottom: viewInsets.bottom,

--- a/lib/src/components/layout/scrollable_client.dart
+++ b/lib/src/components/layout/scrollable_client.dart
@@ -4,6 +4,68 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme data for [ScrollableClient].
+class ScrollableClientTheme {
+  final DiagonalDragBehavior? diagonalDragBehavior;
+  final DragStartBehavior? dragStartBehavior;
+  final ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior;
+  final Clip? clipBehavior;
+  final HitTestBehavior? hitTestBehavior;
+  final bool? overscroll;
+
+  const ScrollableClientTheme({
+    this.diagonalDragBehavior,
+    this.dragStartBehavior,
+    this.keyboardDismissBehavior,
+    this.clipBehavior,
+    this.hitTestBehavior,
+    this.overscroll,
+  });
+
+  ScrollableClientTheme copyWith({
+    ValueGetter<DiagonalDragBehavior?>? diagonalDragBehavior,
+    ValueGetter<DragStartBehavior?>? dragStartBehavior,
+    ValueGetter<ScrollViewKeyboardDismissBehavior?>? keyboardDismissBehavior,
+    ValueGetter<Clip?>? clipBehavior,
+    ValueGetter<HitTestBehavior?>? hitTestBehavior,
+    ValueGetter<bool?>? overscroll,
+  }) {
+    return ScrollableClientTheme(
+      diagonalDragBehavior: diagonalDragBehavior == null
+          ? this.diagonalDragBehavior
+          : diagonalDragBehavior(),
+      dragStartBehavior:
+          dragStartBehavior == null ? this.dragStartBehavior : dragStartBehavior(),
+      keyboardDismissBehavior: keyboardDismissBehavior == null
+          ? this.keyboardDismissBehavior
+          : keyboardDismissBehavior(),
+      clipBehavior:
+          clipBehavior == null ? this.clipBehavior : clipBehavior(),
+      hitTestBehavior:
+          hitTestBehavior == null ? this.hitTestBehavior : hitTestBehavior(),
+      overscroll: overscroll == null ? this.overscroll : overscroll(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is ScrollableClientTheme &&
+      other.diagonalDragBehavior == diagonalDragBehavior &&
+      other.dragStartBehavior == dragStartBehavior &&
+      other.keyboardDismissBehavior == keyboardDismissBehavior &&
+      other.clipBehavior == clipBehavior &&
+      other.hitTestBehavior == hitTestBehavior &&
+      other.overscroll == overscroll;
+
+  @override
+  int get hashCode => Object.hash(diagonalDragBehavior, dragStartBehavior,
+      keyboardDismissBehavior, clipBehavior, hitTestBehavior, overscroll);
+
+  @override
+  String toString() =>
+      'ScrollableClientTheme(diagonalDragBehavior: $diagonalDragBehavior, dragStartBehavior: $dragStartBehavior, keyboardDismissBehavior: $keyboardDismissBehavior, clipBehavior: $clipBehavior, hitTestBehavior: $hitTestBehavior, overscroll: $overscroll)';
+}
+
 typedef ScrollableBuilder = Widget Function(
     BuildContext context, Offset offset, Size viewportSize, Widget? child);
 
@@ -14,12 +76,12 @@ class ScrollableClient extends StatelessWidget {
   final ScrollableDetails horizontalDetails;
   final ScrollableBuilder builder;
   final Widget? child;
-  final DiagonalDragBehavior diagonalDragBehavior;
-  final DragStartBehavior dragStartBehavior;
-  final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
-  final Clip clipBehavior;
-  final HitTestBehavior hitTestBehavior;
-  final bool overscroll;
+  final DiagonalDragBehavior? diagonalDragBehavior;
+  final DragStartBehavior? dragStartBehavior;
+  final ScrollViewKeyboardDismissBehavior? keyboardDismissBehavior;
+  final Clip? clipBehavior;
+  final HitTestBehavior? hitTestBehavior;
+  final bool? overscroll;
 
   const ScrollableClient({
     super.key,
@@ -29,18 +91,20 @@ class ScrollableClient extends StatelessWidget {
     this.horizontalDetails = const ScrollableDetails.horizontal(),
     required this.builder,
     this.child,
-    this.diagonalDragBehavior = DiagonalDragBehavior.none,
-    this.dragStartBehavior = DragStartBehavior.start,
-    this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
-    this.clipBehavior = Clip.hardEdge,
-    this.hitTestBehavior = HitTestBehavior.opaque,
-    this.overscroll = false,
+    this.diagonalDragBehavior,
+    this.dragStartBehavior,
+    this.keyboardDismissBehavior,
+    this.clipBehavior,
+    this.hitTestBehavior,
+    this.overscroll,
   });
 
   Widget _buildViewport(
     BuildContext context,
     ViewportOffset verticalOffset,
     ViewportOffset horizontalOffset,
+    bool overscroll,
+    Clip clipBehavior,
   ) {
     return ScrollableClientViewport(
         overscroll: overscroll,
@@ -79,6 +143,21 @@ class ScrollableClient extends StatelessWidget {
     assert(axisDirectionToAxis(horizontalDetails.direction) == Axis.horizontal,
         'TwoDimensionalScrollView.horizontalDetails are not Axis.horizontal.');
 
+    final compTheme = ComponentTheme.maybeOf<ScrollableClientTheme>(context);
+    final diag = diagonalDragBehavior ??
+        compTheme?.diagonalDragBehavior ??
+        DiagonalDragBehavior.none;
+    final dragStart =
+        dragStartBehavior ?? compTheme?.dragStartBehavior ?? DragStartBehavior.start;
+    final keyboardDismiss = keyboardDismissBehavior ??
+        compTheme?.keyboardDismissBehavior ??
+        ScrollViewKeyboardDismissBehavior.manual;
+    final clip = clipBehavior ?? compTheme?.clipBehavior ?? Clip.hardEdge;
+    final hitTest =
+        hitTestBehavior ?? compTheme?.hitTestBehavior ?? HitTestBehavior.opaque;
+    final bool overscroll =
+        this.overscroll ?? compTheme?.overscroll ?? false;
+
     ScrollableDetails mainAxisDetails = switch (mainAxis) {
       Axis.vertical => verticalDetails,
       Axis.horizontal => horizontalDetails,
@@ -112,10 +191,11 @@ class ScrollableClient extends StatelessWidget {
         Axis.vertical => mainAxisDetails,
         Axis.horizontal => verticalDetails,
       },
-      diagonalDragBehavior: diagonalDragBehavior,
-      viewportBuilder: _buildViewport,
-      dragStartBehavior: dragStartBehavior,
-      hitTestBehavior: hitTestBehavior,
+      diagonalDragBehavior: diag,
+      viewportBuilder: (context, vOffset, hOffset) =>
+          _buildViewport(context, vOffset, hOffset, overscroll, clip),
+      dragStartBehavior: dragStart,
+      hitTestBehavior: hitTest,
     );
 
     final Widget scrollableResult = effectivePrimary
@@ -123,7 +203,7 @@ class ScrollableClient extends StatelessWidget {
         ? PrimaryScrollController.none(child: scrollable)
         : scrollable;
 
-    if (keyboardDismissBehavior == ScrollViewKeyboardDismissBehavior.onDrag) {
+    if (keyboardDismiss == ScrollViewKeyboardDismissBehavior.onDrag) {
       return NotificationListener<ScrollUpdateNotification>(
         child: scrollableResult,
         onNotification: (ScrollUpdateNotification notification) {

--- a/lib/src/components/layout/stepper.dart
+++ b/lib/src/components/layout/stepper.dart
@@ -1,6 +1,37 @@
 import 'package:flutter/foundation.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+class StepperTheme {
+  final Axis? direction;
+  final StepSize? size;
+  final StepVariant? variant;
+
+  const StepperTheme({this.direction, this.size, this.variant});
+
+  StepperTheme copyWith({
+    ValueGetter<Axis?>? direction,
+    ValueGetter<StepSize?>? size,
+    ValueGetter<StepVariant?>? variant,
+  }) {
+    return StepperTheme(
+      direction: direction == null ? this.direction : direction(),
+      size: size == null ? this.size : size(),
+      variant: variant == null ? this.variant : variant(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is StepperTheme &&
+        other.direction == direction &&
+        other.size == size &&
+        other.variant == variant;
+  }
+
+  @override
+  int get hashCode => Object.hash(direction, size, variant);
+}
 enum StepState {
   failed,
 }
@@ -722,26 +753,30 @@ class StepperController extends ValueNotifier<StepperValue> {
 class Stepper extends StatelessWidget {
   final StepperController controller;
   final List<Step> steps;
-  final Axis direction;
-  final StepSize size;
-  final StepVariant variant;
+  final Axis? direction;
+  final StepSize? size;
+  final StepVariant? variant;
 
   const Stepper({
     super.key,
     required this.controller,
     required this.steps,
-    this.direction = Axis.horizontal,
-    this.size = StepSize.medium,
-    this.variant = StepVariant.circle,
+    this.direction,
+    this.size,
+    this.variant,
   });
 
   @override
   Widget build(BuildContext context) {
-    var stepProperties = StepProperties(
-        size: size, steps: steps, state: controller, direction: direction);
+    final compTheme = ComponentTheme.maybeOf<StepperTheme>(context);
+    final dir = direction ?? compTheme?.direction ?? Axis.horizontal;
+    final sz = size ?? compTheme?.size ?? StepSize.medium;
+    final varnt = variant ?? compTheme?.variant ?? StepVariant.circle;
+    var stepProperties =
+        StepProperties(size: sz, steps: steps, state: controller, direction: dir);
     return Data.inherit(
       data: stepProperties,
-      child: variant.build(context, stepProperties),
+      child: varnt.build(context, stepProperties),
     );
   }
 }

--- a/lib/src/components/layout/steps.dart
+++ b/lib/src/components/layout/steps.dart
@@ -1,5 +1,59 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [Steps].
+class StepsTheme {
+  /// Diameter of the step indicator circle.
+  final double? indicatorSize;
+
+  /// Gap between the indicator and the step content.
+  final double? spacing;
+
+  /// Color of the indicator and connector line.
+  final Color? indicatorColor;
+
+  /// Thickness of the connector line.
+  final double? connectorThickness;
+
+  const StepsTheme({
+    this.indicatorSize,
+    this.spacing,
+    this.indicatorColor,
+    this.connectorThickness,
+  });
+
+  StepsTheme copyWith({
+    ValueGetter<double?>? indicatorSize,
+    ValueGetter<double?>? spacing,
+    ValueGetter<Color?>? indicatorColor,
+    ValueGetter<double?>? connectorThickness,
+  }) {
+    return StepsTheme(
+      indicatorSize:
+          indicatorSize == null ? this.indicatorSize : indicatorSize(),
+      spacing: spacing == null ? this.spacing : spacing(),
+      indicatorColor:
+          indicatorColor == null ? this.indicatorColor : indicatorColor(),
+      connectorThickness: connectorThickness == null
+          ? this.connectorThickness
+          : connectorThickness(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is StepsTheme &&
+        other.indicatorSize == indicatorSize &&
+        other.spacing == spacing &&
+        other.indicatorColor == indicatorColor &&
+        other.connectorThickness == connectorThickness;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(indicatorSize, spacing, indicatorColor, connectorThickness);
+}
+
 class Steps extends StatelessWidget {
   final List<Widget> children;
 
@@ -12,6 +66,14 @@ class Steps extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<StepsTheme>(context);
+    final indicatorSize =
+        compTheme?.indicatorSize ?? 28 * scaling;
+    final spacing = compTheme?.spacing ?? 18 * scaling;
+    final indicatorColor =
+        compTheme?.indicatorColor ?? theme.colorScheme.muted;
+    final connectorThickness =
+        compTheme?.connectorThickness ?? 1 * scaling;
     List<Widget> mapped = [];
     for (var i = 0; i < children.length; i++) {
       mapped.add(IntrinsicHeight(
@@ -24,11 +86,11 @@ class Steps extends StatelessWidget {
               children: [
                 Container(
                   decoration: BoxDecoration(
-                    color: theme.colorScheme.muted,
+                    color: indicatorColor,
                     shape: BoxShape.circle,
                   ),
-                  width: 28 * scaling,
-                  height: 28 * scaling,
+                  width: indicatorSize,
+                  height: indicatorSize,
                   child: Center(
                     child: Text(
                       (i + 1).toString(),
@@ -36,11 +98,15 @@ class Steps extends StatelessWidget {
                   ),
                 ),
                 Gap(4 * scaling),
-                const Expanded(child: VerticalDivider()),
+                Expanded(
+                    child: VerticalDivider(
+                  thickness: connectorThickness,
+                  color: indicatorColor,
+                )),
                 Gap(4 * scaling),
               ],
             ),
-            Gap(18 * scaling),
+            Gap(spacing),
             Expanded(child: children[i].withPadding(bottom: 32 * scaling)),
           ],
         ),

--- a/lib/src/components/layout/timeline.dart
+++ b/lib/src/components/layout/timeline.dart
@@ -1,5 +1,72 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [Timeline].
+class TimelineTheme {
+  /// Constraints for the time column.
+  final BoxConstraints? timeConstraints;
+
+  /// Spacing between columns.
+  final double? spacing;
+
+  /// Diameter of the timeline indicator.
+  final double? dotSize;
+
+  /// Thickness of the connector line.
+  final double? connectorThickness;
+
+  /// Default color of the indicator and connector when data color is not provided.
+  final Color? color;
+
+  /// Gap between each timeline row.
+  final double? rowGap;
+
+  const TimelineTheme({
+    this.timeConstraints,
+    this.spacing,
+    this.dotSize,
+    this.connectorThickness,
+    this.color,
+    this.rowGap,
+  });
+
+  TimelineTheme copyWith({
+    ValueGetter<BoxConstraints?>? timeConstraints,
+    ValueGetter<double?>? spacing,
+    ValueGetter<double?>? dotSize,
+    ValueGetter<double?>? connectorThickness,
+    ValueGetter<Color?>? color,
+    ValueGetter<double?>? rowGap,
+  }) {
+    return TimelineTheme(
+      timeConstraints:
+          timeConstraints == null ? this.timeConstraints : timeConstraints(),
+      spacing: spacing == null ? this.spacing : spacing(),
+      dotSize: dotSize == null ? this.dotSize : dotSize(),
+      connectorThickness: connectorThickness == null
+          ? this.connectorThickness
+          : connectorThickness(),
+      color: color == null ? this.color : color(),
+      rowGap: rowGap == null ? this.rowGap : rowGap(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TimelineTheme &&
+        other.timeConstraints == timeConstraints &&
+        other.spacing == spacing &&
+        other.dotSize == dotSize &&
+        other.connectorThickness == connectorThickness &&
+        other.color == color &&
+        other.rowGap == rowGap;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      timeConstraints, spacing, dotSize, connectorThickness, color, rowGap);
+}
+
 class TimelineData {
   final Widget time;
   final Widget title;
@@ -32,6 +99,16 @@ class Timeline extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<TimelineTheme>(context);
+    final timeConstraints = this.timeConstraints ??
+        compTheme?.timeConstraints ??
+        BoxConstraints(minWidth: 120 * scaling, maxWidth: 120 * scaling);
+    final spacing = compTheme?.spacing ?? 16 * scaling;
+    final dotSize = compTheme?.dotSize ?? 12 * scaling;
+    final connectorThickness =
+        compTheme?.connectorThickness ?? 2 * scaling;
+    final defaultColor = compTheme?.color ?? theme.colorScheme.primary;
+    final rowGap = compTheme?.rowGap ?? 16 * scaling;
     List<Widget> rows = [];
     for (int i = 0; i < data.length; i++) {
       final data = this.data[i];
@@ -40,42 +117,38 @@ class Timeline extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             ConstrainedBox(
-              constraints: timeConstraints ??
-                  BoxConstraints(
-                    minWidth: 120 * scaling,
-                    maxWidth: 120 * scaling,
-                  ),
+              constraints: timeConstraints,
               child: Align(
                 alignment: Alignment.topRight,
                 child: data.time.medium().small(),
               ),
             ),
-            Gap(16 * scaling),
+            Gap(spacing),
             Column(
               mainAxisSize: MainAxisSize.min,
               children: [
                 Container(
                   margin: EdgeInsets.only(top: 4 * scaling),
-                  width: 12 * scaling,
-                  height: 12 * scaling,
+                  width: dotSize,
+                  height: dotSize,
                   decoration: BoxDecoration(
                     shape: theme.radius == 0
                         ? BoxShape.rectangle
                         : BoxShape.circle,
-                    color: data.color ?? theme.colorScheme.primary,
+                    color: data.color ?? defaultColor,
                   ),
                 ),
                 if (i != this.data.length - 1)
                   Expanded(
                     child: VerticalDivider(
-                      thickness: 2 * scaling,
-                      color: data.color ?? theme.colorScheme.primary,
-                      endIndent: (-4 - 16) * scaling,
+                      thickness: connectorThickness,
+                      color: data.color ?? defaultColor,
+                      endIndent: (-4 - spacing) * scaling,
                     ),
                   ),
               ],
             ),
-            Gap(16 * scaling),
+            Gap(spacing),
             Expanded(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -98,6 +171,6 @@ class Timeline extends StatelessWidget {
     }
     return Column(
       children: rows,
-    ).gap(16 * scaling);
+    ).gap(rowGap);
   }
 }

--- a/lib/src/components/menu/context_menu.dart
+++ b/lib/src/components/menu/context_menu.dart
@@ -2,6 +2,41 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [ContextMenuPopup] and context menu widgets.
+class ContextMenuTheme {
+  /// Surface opacity for the popup container.
+  final double? surfaceOpacity;
+
+  /// Surface blur for the popup container.
+  final double? surfaceBlur;
+
+  /// Creates a [ContextMenuTheme].
+  const ContextMenuTheme({this.surfaceOpacity, this.surfaceBlur});
+
+  /// Returns a copy of this theme with the given fields replaced.
+  ContextMenuTheme copyWith({
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+  }) {
+    return ContextMenuTheme(
+      surfaceOpacity:
+          surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
+      surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ContextMenuTheme &&
+        other.surfaceOpacity == surfaceOpacity &&
+        other.surfaceBlur == surfaceBlur;
+  }
+
+  @override
+  int get hashCode => Object.hash(surfaceOpacity, surfaceBlur);
+}
+
 class DesktopEditableTextContextMenu extends StatelessWidget {
   final BuildContext anchorContext;
   final EditableTextState editableTextState;
@@ -519,7 +554,11 @@ Future<void> _showContextMenu(
                       closeOverlay(context);
                     },
                     builder: (context, children) {
+                      final compTheme =
+                          ComponentTheme.maybeOf<ContextMenuTheme>(context);
                       return MenuPopup(
+                        surfaceOpacity: compTheme?.surfaceOpacity,
+                        surfaceBlur: compTheme?.surfaceBlur,
                         children: children,
                       );
                     },
@@ -577,7 +616,11 @@ class ContextMenuPopup extends StatelessWidget {
                     ? const EdgeInsets.symmetric(horizontal: 8) * theme.scaling
                     : EdgeInsets.zero,
                 builder: (context, children) {
+                  final compTheme =
+                      ComponentTheme.maybeOf<ContextMenuTheme>(context);
                   return MenuPopup(
+                    surfaceOpacity: compTheme?.surfaceOpacity,
+                    surfaceBlur: compTheme?.surfaceBlur,
                     children: children,
                   );
                 },

--- a/lib/src/components/menu/dropdown_menu.dart
+++ b/lib/src/components/menu/dropdown_menu.dart
@@ -67,6 +67,41 @@ class DropdownMenuData {
   DropdownMenuData(this.key);
 }
 
+/// Theme for [DropdownMenu].
+class DropdownMenuTheme {
+  /// Surface opacity for the popup container.
+  final double? surfaceOpacity;
+
+  /// Surface blur for the popup container.
+  final double? surfaceBlur;
+
+  /// Creates a [DropdownMenuTheme].
+  const DropdownMenuTheme({this.surfaceOpacity, this.surfaceBlur});
+
+  /// Returns a copy of this theme with the given fields replaced.
+  DropdownMenuTheme copyWith({
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+  }) {
+    return DropdownMenuTheme(
+      surfaceOpacity:
+          surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
+      surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is DropdownMenuTheme &&
+        other.surfaceOpacity == surfaceOpacity &&
+        other.surfaceBlur == surfaceBlur;
+  }
+
+  @override
+  int get hashCode => Object.hash(surfaceOpacity, surfaceBlur);
+}
+
 class DropdownMenu extends StatefulWidget {
   final double? surfaceOpacity;
   final double? surfaceBlur;
@@ -88,6 +123,7 @@ class _DropdownMenuState extends State<DropdownMenu> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isSheetOverlay = SheetOverlayHandler.isSheetOverlay(context);
+    final compTheme = ComponentTheme.maybeOf<DropdownMenuTheme>(context);
     return ConstrainedBox(
       constraints: const BoxConstraints(
         minWidth: 192,
@@ -106,8 +142,9 @@ class _DropdownMenuState extends State<DropdownMenu> {
           return MenuPopup(
             // does not need to check for theme.surfaceOpacity and theme.surfaceBlur
             // MenuPopup already has default values for these properties
-            surfaceOpacity: widget.surfaceOpacity,
-            surfaceBlur: widget.surfaceBlur,
+            surfaceOpacity:
+                widget.surfaceOpacity ?? compTheme?.surfaceOpacity,
+            surfaceBlur: widget.surfaceBlur ?? compTheme?.surfaceBlur,
             children: children,
           );
         },

--- a/lib/src/components/menu/menubar.dart
+++ b/lib/src/components/menu/menubar.dart
@@ -1,5 +1,79 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [Menubar].
+class MenubarTheme {
+  /// Whether to draw border around the menubar.
+  final bool? border;
+
+  /// Offset of submenu popovers.
+  final Offset? subMenuOffset;
+
+  /// Padding inside the menubar.
+  final EdgeInsetsGeometry? padding;
+
+  /// Color of the border when [border] is true.
+  final Color? borderColor;
+
+  /// Background color of the menubar container.
+  final Color? backgroundColor;
+
+  /// Border radius of the menubar container.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Creates a [MenubarTheme].
+  const MenubarTheme({
+    this.border,
+    this.subMenuOffset,
+    this.padding,
+    this.borderColor,
+    this.backgroundColor,
+    this.borderRadius,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  MenubarTheme copyWith({
+    ValueGetter<bool?>? border,
+    ValueGetter<Offset?>? subMenuOffset,
+    ValueGetter<EdgeInsetsGeometry?>? padding,
+    ValueGetter<Color?>? borderColor,
+    ValueGetter<Color?>? backgroundColor,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+  }) {
+    return MenubarTheme(
+      border: border == null ? this.border : border(),
+      subMenuOffset:
+          subMenuOffset == null ? this.subMenuOffset : subMenuOffset(),
+      padding: padding == null ? this.padding : padding(),
+      borderColor: borderColor == null ? this.borderColor : borderColor(),
+      backgroundColor:
+          backgroundColor == null ? this.backgroundColor : backgroundColor(),
+      borderRadius: borderRadius == null ? this.borderRadius : borderRadius(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is MenubarTheme &&
+        other.border == border &&
+        other.subMenuOffset == subMenuOffset &&
+        other.padding == padding &&
+        other.borderColor == borderColor &&
+        other.backgroundColor == backgroundColor &&
+        other.borderRadius == borderRadius;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        border,
+        subMenuOffset,
+        padding,
+        borderColor,
+        backgroundColor,
+        borderRadius,
+      );
+}
+
 class Menubar extends StatefulWidget {
   final List<MenuItem> children;
   final Offset? popoverOffset;
@@ -20,31 +94,43 @@ class MenubarState extends State<Menubar> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    if (widget.border) {
+    final compTheme = ComponentTheme.maybeOf<MenubarTheme>(context);
+    final bool border = compTheme?.border ?? widget.border;
+    final borderColor = compTheme?.borderColor ?? theme.colorScheme.border;
+    final backgroundColor =
+        compTheme?.backgroundColor ?? theme.colorScheme.background;
+    final borderRadius = compTheme?.borderRadius ?? theme.borderRadiusMd;
+    final padding = compTheme?.padding ?? const EdgeInsets.all(4) * theme.scaling;
+
+    if (border) {
       return OutlinedContainer(
-        borderColor: theme.colorScheme.border,
-        backgroundColor: theme.colorScheme.background,
-        borderRadius: theme.borderRadiusMd,
+        borderColor: borderColor,
+        backgroundColor: backgroundColor,
+        borderRadius: borderRadius,
         child: AnimatedPadding(
           duration: kDefaultDuration,
-          padding: const EdgeInsets.all(4) * theme.scaling,
-          child: buildContainer(context, theme),
+          padding: padding,
+          child: buildContainer(context, theme,
+              compTheme?.subMenuOffset ?? widget.popoverOffset, border),
         ),
       );
     }
-    return buildContainer(context, theme);
+    return buildContainer(
+        context, theme, compTheme?.subMenuOffset ?? widget.popoverOffset, border);
   }
 
-  Widget buildContainer(BuildContext context, ThemeData theme) {
+  Widget buildContainer(
+      BuildContext context, ThemeData theme, Offset? subMenuOffset, bool border) {
+    final scaling = theme.scaling;
+    final offset = subMenuOffset ??
+        ((border ? const Offset(-4, 8) : const Offset(0, 4)) * scaling);
     return Data.inherit(
       data: this,
       child: MenuGroup(
         regionGroupId: this,
         direction: Axis.vertical,
         itemPadding: EdgeInsets.zero,
-        subMenuOffset:
-            (widget.border ? const Offset(-4, 8) : const Offset(0, 4)) *
-                theme.scaling,
+        subMenuOffset: offset,
         builder: (context, children) {
           return IntrinsicHeight(
             child: Row(

--- a/lib/src/components/menu/navigation_menu.dart
+++ b/lib/src/components/menu/navigation_menu.dart
@@ -1,5 +1,57 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// Theme for [NavigationMenu].
+class NavigationMenuTheme {
+  /// Opacity of the popover surface.
+  final double? surfaceOpacity;
+
+  /// Blur amount of the popover surface.
+  final double? surfaceBlur;
+
+  /// Margin applied to the popover.
+  final EdgeInsetsGeometry? margin;
+
+  /// Offset for the popover relative to the trigger.
+  final Offset? offset;
+
+  /// Creates a [NavigationMenuTheme].
+  const NavigationMenuTheme({
+    this.surfaceOpacity,
+    this.surfaceBlur,
+    this.margin,
+    this.offset,
+  });
+
+  /// Returns a copy of this theme with the given fields replaced.
+  NavigationMenuTheme copyWith({
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+    ValueGetter<EdgeInsetsGeometry?>? margin,
+    ValueGetter<Offset?>? offset,
+  }) {
+    return NavigationMenuTheme(
+      surfaceOpacity:
+          surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
+      surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+      margin: margin == null ? this.margin : margin(),
+      offset: offset == null ? this.offset : offset(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NavigationMenuTheme &&
+        other.surfaceOpacity == surfaceOpacity &&
+        other.surfaceBlur == surfaceBlur &&
+        other.margin == margin &&
+        other.offset == offset;
+  }
+
+  @override
+  int get hashCode => Object.hash(surfaceOpacity, surfaceBlur, margin, offset);
+}
+
 class NavigationMenuItem extends StatefulWidget {
   final VoidCallback? onPressed;
   final Widget? content;
@@ -256,18 +308,21 @@ class NavigationMenuState extends State<NavigationMenu> {
     }
     final theme = Theme.of(context);
     final scaling = theme.scaling;
+    final compTheme = ComponentTheme.maybeOf<NavigationMenuTheme>(context);
     _popoverController.show(
       context: context,
       alignment: Alignment.topCenter,
       regionGroupId: this,
-      offset: const Offset(0, 4) * scaling,
+      offset: compTheme?.offset ?? const Offset(0, 4) * scaling,
       builder: buildPopover,
       modal: false,
-      margin: requestMargin() ?? (const EdgeInsets.all(8) * scaling),
+      margin:
+          requestMargin() ?? compTheme?.margin ?? (const EdgeInsets.all(8) * scaling),
       allowInvertHorizontal: false,
       allowInvertVertical: false,
       onTickFollow: (value) {
-        value.margin = requestMargin() ?? (const EdgeInsets.all(8) * scaling);
+        value.margin =
+            requestMargin() ?? compTheme?.margin ?? (const EdgeInsets.all(8) * scaling);
       },
     );
   }
@@ -309,8 +364,12 @@ class NavigationMenuState extends State<NavigationMenu> {
 
   Widget buildPopover(BuildContext context) {
     final theme = Theme.of(context);
-    final surfaceOpacity = widget.surfaceOpacity ?? theme.surfaceOpacity;
-    final surfaceBlur = widget.surfaceBlur ?? theme.surfaceBlur;
+    final compTheme = ComponentTheme.maybeOf<NavigationMenuTheme>(context);
+    final surfaceOpacity = widget.surfaceOpacity ??
+        compTheme?.surfaceOpacity ??
+        theme.surfaceOpacity;
+    final surfaceBlur =
+        widget.surfaceBlur ?? compTheme?.surfaceBlur ?? theme.surfaceBlur;
     return MouseRegion(
       hitTestBehavior: HitTestBehavior.translucent,
       onEnter: (_) {

--- a/lib/src/components/navigation/tabs/tab_container.dart
+++ b/lib/src/components/navigation/tabs/tab_container.dart
@@ -1,5 +1,50 @@
 import '../../../../shadcn_flutter.dart';
 
+/// {@template tab_container_theme}
+/// Theme data for [TabContainer] providing default builders.
+/// {@endtemplate}
+class TabContainerTheme {
+  /// Default builder for laying out tab children.
+  final TabBuilder? builder;
+
+  /// Default builder for wrapping each tab child.
+  final TabChildBuilder? childBuilder;
+
+  /// {@macro tab_container_theme}
+  const TabContainerTheme({
+    this.builder,
+    this.childBuilder,
+  });
+
+  /// Creates a copy of this theme with the given fields replaced.
+  TabContainerTheme copyWith({
+    ValueGetter<TabBuilder?>? builder,
+    ValueGetter<TabChildBuilder?>? childBuilder,
+  }) {
+    return TabContainerTheme(
+      builder: builder == null ? this.builder : builder(),
+      childBuilder:
+          childBuilder == null ? this.childBuilder : childBuilder(),
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(builder, childBuilder);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TabContainerTheme &&
+        other.builder == builder &&
+        other.childBuilder == childBuilder;
+  }
+
+  @override
+  String toString() {
+    return 'TabContainerTheme(builder: $builder, childBuilder: $childBuilder)';
+  }
+}
+
 class TabContainerData {
   static TabContainerData of(BuildContext context) {
     var data = Data.maybeOf<TabContainerData>(context);
@@ -112,20 +157,26 @@ class TabContainer extends StatelessWidget {
   final int selected;
   final ValueChanged<int>? onSelect;
   final List<TabChild> children;
-  final TabBuilder builder;
-  final TabChildBuilder childBuilder;
+  final TabBuilder? builder;
+  final TabChildBuilder? childBuilder;
 
   const TabContainer({
     super.key,
     required this.selected,
     required this.onSelect,
     required this.children,
-    required this.builder,
-    required this.childBuilder,
+    this.builder,
+    this.childBuilder,
   });
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<TabContainerTheme>(context);
+    final tabBuilder =
+        builder ?? compTheme?.builder ?? (context, children) => Column(children: children);
+    final tabChildBuilder =
+        childBuilder ?? compTheme?.childBuilder ?? ((_, __, child) => child);
+
     List<Widget> wrappedChildren = [];
     int index = 0;
     for (TabChild child in children) {
@@ -137,19 +188,17 @@ class TabContainer extends StatelessWidget {
               index: index,
               selected: selected,
               onSelect: onSelect,
-              childBuilder: childBuilder,
+              childBuilder: tabChildBuilder,
             ),
             child: child,
           ),
         );
         index++;
       } else {
-        wrappedChildren.add(
-          child,
-        );
+        wrappedChildren.add(child);
       }
     }
-    return builder(
+    return tabBuilder(
       context,
       wrappedChildren,
     );

--- a/lib/src/components/overlay/drawer.dart
+++ b/lib/src/components/overlay/drawer.dart
@@ -6,6 +6,61 @@ import 'package:shadcn_flutter/shadcn_flutter.dart';
 typedef DrawerBuilder = Widget Function(BuildContext context, Size extraSize,
     Size size, EdgeInsets padding, int stackIndex);
 
+/// Theme data for drawer and sheet overlays.
+class DrawerTheme {
+  final double? surfaceOpacity;
+  final double? surfaceBlur;
+  final Color? barrierColor;
+  final bool? showDragHandle;
+  final Size? dragHandleSize;
+
+  const DrawerTheme({
+    this.surfaceOpacity,
+    this.surfaceBlur,
+    this.barrierColor,
+    this.showDragHandle,
+    this.dragHandleSize,
+  });
+
+  DrawerTheme copyWith({
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+    ValueGetter<Color?>? barrierColor,
+    ValueGetter<bool?>? showDragHandle,
+    ValueGetter<Size?>? dragHandleSize,
+  }) {
+    return DrawerTheme(
+      surfaceOpacity:
+          surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
+      surfaceBlur:
+          surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+      barrierColor:
+          barrierColor == null ? this.barrierColor : barrierColor(),
+      showDragHandle:
+          showDragHandle == null ? this.showDragHandle : showDragHandle(),
+      dragHandleSize:
+          dragHandleSize == null ? this.dragHandleSize : dragHandleSize(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is DrawerTheme &&
+      other.surfaceOpacity == surfaceOpacity &&
+      other.surfaceBlur == surfaceBlur &&
+      other.barrierColor == barrierColor &&
+      other.showDragHandle == showDragHandle &&
+      other.dragHandleSize == dragHandleSize;
+
+  @override
+  int get hashCode =>
+      Object.hash(surfaceOpacity, surfaceBlur, barrierColor, showDragHandle, dragHandleSize);
+
+  @override
+  String toString() =>
+      'DrawerTheme(surfaceOpacity: $surfaceOpacity, surfaceBlur: $surfaceBlur, barrierColor: $barrierColor, showDragHandle: $showDragHandle, dragHandleSize: $dragHandleSize)';
+}
+
 DrawerOverlayCompleter<T?> openDrawerOverlay<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -15,7 +70,7 @@ DrawerOverlayCompleter<T?> openDrawerOverlay<T>({
   bool barrierDismissible = true,
   WidgetBuilder? backdropBuilder,
   bool useSafeArea = true,
-  bool showDragHandle = true,
+  bool? showDragHandle,
   BorderRadiusGeometry? borderRadius,
   Size? dragHandleSize,
   bool transformBackdrop = true,
@@ -27,6 +82,12 @@ DrawerOverlayCompleter<T?> openDrawerOverlay<T>({
   BoxConstraints? constraints,
   AlignmentGeometry? alignment,
 }) {
+  final theme = ComponentTheme.maybeOf<DrawerTheme>(context);
+  showDragHandle ??= theme?.showDragHandle ?? true;
+  surfaceOpacity ??= theme?.surfaceOpacity;
+  surfaceBlur ??= theme?.surfaceBlur;
+  barrierColor ??= theme?.barrierColor;
+  dragHandleSize ??= theme?.dragHandleSize;
   return openRawDrawer<T>(
     context: context,
     barrierDismissible: barrierDismissible,
@@ -75,6 +136,8 @@ DrawerOverlayCompleter<T?> openSheetOverlay<T>({
   BoxConstraints? constraints,
   AlignmentGeometry? alignment,
 }) {
+  final theme = ComponentTheme.maybeOf<DrawerTheme>(context);
+  barrierColor ??= theme?.barrierColor;
   return openRawDrawer<T>(
     context: context,
     transformBackdrop: transformBackdrop,
@@ -113,7 +176,7 @@ Future<T?> openDrawer<T>({
   bool barrierDismissible = true,
   WidgetBuilder? backdropBuilder,
   bool useSafeArea = true,
-  bool showDragHandle = true,
+  bool? showDragHandle,
   BorderRadiusGeometry? borderRadius,
   Size? dragHandleSize,
   bool transformBackdrop = true,

--- a/lib/src/components/overlay/swiper.dart
+++ b/lib/src/components/overlay/swiper.dart
@@ -1,5 +1,123 @@
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// {@template swiper_theme}
+/// Theme data for [Swiper] providing default overlay configuration.
+/// {@endtemplate}
+class SwiperTheme {
+  final bool? expands;
+  final bool? draggable;
+  final bool? barrierDismissible;
+  final WidgetBuilder? backdropBuilder;
+  final bool? useSafeArea;
+  final bool? showDragHandle;
+  final BorderRadiusGeometry? borderRadius;
+  final Size? dragHandleSize;
+  final bool? transformBackdrop;
+  final double? surfaceOpacity;
+  final double? surfaceBlur;
+  final Color? barrierColor;
+  final HitTestBehavior? behavior;
+
+  /// {@macro swiper_theme}
+  const SwiperTheme({
+    this.expands,
+    this.draggable,
+    this.barrierDismissible,
+    this.backdropBuilder,
+    this.useSafeArea,
+    this.showDragHandle,
+    this.borderRadius,
+    this.dragHandleSize,
+    this.transformBackdrop,
+    this.surfaceOpacity,
+    this.surfaceBlur,
+    this.barrierColor,
+    this.behavior,
+  });
+
+  SwiperTheme copyWith({
+    ValueGetter<bool?>? expands,
+    ValueGetter<bool?>? draggable,
+    ValueGetter<bool?>? barrierDismissible,
+    ValueGetter<WidgetBuilder?>? backdropBuilder,
+    ValueGetter<bool?>? useSafeArea,
+    ValueGetter<bool?>? showDragHandle,
+    ValueGetter<BorderRadiusGeometry?>? borderRadius,
+    ValueGetter<Size?>? dragHandleSize,
+    ValueGetter<bool?>? transformBackdrop,
+    ValueGetter<double?>? surfaceOpacity,
+    ValueGetter<double?>? surfaceBlur,
+    ValueGetter<Color?>? barrierColor,
+    ValueGetter<HitTestBehavior?>? behavior,
+  }) {
+    return SwiperTheme(
+      expands: expands == null ? this.expands : expands(),
+      draggable: draggable == null ? this.draggable : draggable(),
+      barrierDismissible: barrierDismissible == null
+          ? this.barrierDismissible
+          : barrierDismissible(),
+      backdropBuilder:
+          backdropBuilder == null ? this.backdropBuilder : backdropBuilder(),
+      useSafeArea: useSafeArea == null ? this.useSafeArea : useSafeArea(),
+      showDragHandle:
+          showDragHandle == null ? this.showDragHandle : showDragHandle(),
+      borderRadius:
+          borderRadius == null ? this.borderRadius : borderRadius(),
+      dragHandleSize:
+          dragHandleSize == null ? this.dragHandleSize : dragHandleSize(),
+      transformBackdrop: transformBackdrop == null
+          ? this.transformBackdrop
+          : transformBackdrop(),
+      surfaceOpacity:
+          surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
+      surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+      barrierColor:
+          barrierColor == null ? this.barrierColor : barrierColor(),
+      behavior: behavior == null ? this.behavior : behavior(),
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      expands,
+      draggable,
+      barrierDismissible,
+      backdropBuilder,
+      useSafeArea,
+      showDragHandle,
+      borderRadius,
+      dragHandleSize,
+      transformBackdrop,
+      surfaceOpacity,
+      surfaceBlur,
+      barrierColor,
+      behavior);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SwiperTheme &&
+        other.expands == expands &&
+        other.draggable == draggable &&
+        other.barrierDismissible == barrierDismissible &&
+        other.backdropBuilder == backdropBuilder &&
+        other.useSafeArea == useSafeArea &&
+        other.showDragHandle == showDragHandle &&
+        other.borderRadius == borderRadius &&
+        other.dragHandleSize == dragHandleSize &&
+        other.transformBackdrop == transformBackdrop &&
+        other.surfaceOpacity == surfaceOpacity &&
+        other.surfaceBlur == surfaceBlur &&
+        other.barrierColor == barrierColor &&
+        other.behavior == behavior;
+  }
+
+  @override
+  String toString() {
+    return 'SwiperTheme(expands: $expands, draggable: $draggable, barrierDismissible: $barrierDismissible, backdropBuilder: $backdropBuilder, useSafeArea: $useSafeArea, showDragHandle: $showDragHandle, borderRadius: $borderRadius, dragHandleSize: $dragHandleSize, transformBackdrop: $transformBackdrop, surfaceOpacity: $surfaceOpacity, surfaceBlur: $surfaceBlur, barrierColor: $barrierColor, behavior: $behavior)';
+  }
+}
+
 abstract class SwiperHandler {
   static const SwiperHandler drawer = DrawerSwiperHandler();
   static const SwiperHandler sheet = SheetSwiperHandler();
@@ -239,6 +357,7 @@ class _SwiperState extends State<Swiper> {
 
   void _onDragStart(DragStartDetails details) {
     _onDragCancel();
+    final compTheme = ComponentTheme.maybeOf<SwiperTheme>(context);
     _activeOverlay = widget.handler.openSwiper(
       context: context,
       builder: (context) {
@@ -248,18 +367,20 @@ class _SwiperState extends State<Swiper> {
         );
       },
       position: widget.position,
-      expands: widget.expands,
-      draggable: widget.draggable,
-      barrierDismissible: widget.barrierDismissible,
-      backdropBuilder: widget.backdropBuilder,
-      useSafeArea: widget.useSafeArea,
-      showDragHandle: widget.showDragHandle,
-      borderRadius: widget.borderRadius,
-      dragHandleSize: widget.dragHandleSize,
-      transformBackdrop: widget.transformBackdrop,
-      surfaceOpacity: widget.surfaceOpacity,
-      surfaceBlur: widget.surfaceBlur,
-      barrierColor: widget.barrierColor,
+      expands: widget.expands ?? compTheme?.expands,
+      draggable: widget.draggable ?? compTheme?.draggable,
+      barrierDismissible:
+          widget.barrierDismissible ?? compTheme?.barrierDismissible,
+      backdropBuilder: widget.backdropBuilder ?? compTheme?.backdropBuilder,
+      useSafeArea: widget.useSafeArea ?? compTheme?.useSafeArea,
+      showDragHandle: widget.showDragHandle ?? compTheme?.showDragHandle,
+      borderRadius: widget.borderRadius ?? compTheme?.borderRadius,
+      dragHandleSize: widget.dragHandleSize ?? compTheme?.dragHandleSize,
+      transformBackdrop:
+          widget.transformBackdrop ?? compTheme?.transformBackdrop,
+      surfaceOpacity: widget.surfaceOpacity ?? compTheme?.surfaceOpacity,
+      surfaceBlur: widget.surfaceBlur ?? compTheme?.surfaceBlur,
+      barrierColor: widget.barrierColor ?? compTheme?.barrierColor,
     );
   }
 
@@ -267,10 +388,13 @@ class _SwiperState extends State<Swiper> {
     required Widget child,
     required bool draggable,
   }) {
+    final compTheme = ComponentTheme.maybeOf<SwiperTheme>(context);
+    final behavior =
+        widget.behavior ?? compTheme?.behavior ?? HitTestBehavior.translucent;
     if (widget.position == OverlayPosition.top ||
         widget.position == OverlayPosition.bottom) {
       return GestureDetector(
-        behavior: widget.behavior ?? HitTestBehavior.translucent,
+        behavior: behavior,
         onVerticalDragUpdate: draggable ? _onDrag : null,
         onVerticalDragEnd: draggable ? _onDragEnd : null,
         onVerticalDragStart: draggable ? _onDragStart : null,
@@ -279,7 +403,7 @@ class _SwiperState extends State<Swiper> {
       );
     }
     return GestureDetector(
-      behavior: widget.behavior ?? HitTestBehavior.translucent,
+      behavior: behavior,
       onHorizontalDragUpdate: draggable ? _onDrag : null,
       onHorizontalDragEnd: draggable ? _onDragEnd : null,
       onHorizontalDragStart: draggable ? _onDragStart : null,

--- a/lib/src/components/text/selectable.dart
+++ b/lib/src/components/text/selectable.dart
@@ -4,6 +4,79 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' as m;
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
+/// {@template selectable_text_theme}
+/// Theme data for [SelectableText] to customize cursor and selection behavior.
+/// {@endtemplate}
+class SelectableTextTheme {
+  final double? cursorWidth;
+  final double? cursorHeight;
+  final Radius? cursorRadius;
+  final Color? cursorColor;
+  final ui.BoxHeightStyle? selectionHeightStyle;
+  final ui.BoxWidthStyle? selectionWidthStyle;
+  final bool? enableInteractiveSelection;
+
+  /// {@macro selectable_text_theme}
+  const SelectableTextTheme({
+    this.cursorWidth,
+    this.cursorHeight,
+    this.cursorRadius,
+    this.cursorColor,
+    this.selectionHeightStyle,
+    this.selectionWidthStyle,
+    this.enableInteractiveSelection,
+  });
+
+  SelectableTextTheme copyWith({
+    ValueGetter<double?>? cursorWidth,
+    ValueGetter<double?>? cursorHeight,
+    ValueGetter<Radius?>? cursorRadius,
+    ValueGetter<Color?>? cursorColor,
+    ValueGetter<ui.BoxHeightStyle?>? selectionHeightStyle,
+    ValueGetter<ui.BoxWidthStyle?>? selectionWidthStyle,
+    ValueGetter<bool?>? enableInteractiveSelection,
+  }) {
+    return SelectableTextTheme(
+      cursorWidth: cursorWidth == null ? this.cursorWidth : cursorWidth(),
+      cursorHeight: cursorHeight == null ? this.cursorHeight : cursorHeight(),
+      cursorRadius: cursorRadius == null ? this.cursorRadius : cursorRadius(),
+      cursorColor: cursorColor == null ? this.cursorColor : cursorColor(),
+      selectionHeightStyle: selectionHeightStyle == null
+          ? this.selectionHeightStyle
+          : selectionHeightStyle(),
+      selectionWidthStyle: selectionWidthStyle == null
+          ? this.selectionWidthStyle
+          : selectionWidthStyle(),
+      enableInteractiveSelection: enableInteractiveSelection == null
+          ? this.enableInteractiveSelection
+          : enableInteractiveSelection(),
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(cursorWidth, cursorHeight, cursorRadius,
+      cursorColor, selectionHeightStyle, selectionWidthStyle,
+      enableInteractiveSelection);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SelectableTextTheme &&
+        other.cursorWidth == cursorWidth &&
+        other.cursorHeight == cursorHeight &&
+        other.cursorRadius == cursorRadius &&
+        other.cursorColor == cursorColor &&
+        other.selectionHeightStyle == selectionHeightStyle &&
+        other.selectionWidthStyle == selectionWidthStyle &&
+        other.enableInteractiveSelection == enableInteractiveSelection;
+  }
+
+  @override
+  String toString() {
+    return 'SelectableTextTheme(cursorWidth: $cursorWidth, cursorHeight: $cursorHeight, cursorRadius: $cursorRadius, cursorColor: $cursorColor, selectionHeightStyle: $selectionHeightStyle, selectionWidthStyle: $selectionWidthStyle, enableInteractiveSelection: $enableInteractiveSelection)';
+  }
+}
+
 class SelectableText extends StatelessWidget {
   const SelectableText(
     String this.data, {
@@ -192,6 +265,18 @@ class SelectableText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final compTheme = ComponentTheme.maybeOf<SelectableTextTheme>(context);
+    final cursorWidth = compTheme?.cursorWidth ?? this.cursorWidth;
+    final cursorHeight = compTheme?.cursorHeight ?? this.cursorHeight;
+    final cursorRadius = compTheme?.cursorRadius ?? this.cursorRadius;
+    final cursorColor = compTheme?.cursorColor ?? this.cursorColor;
+    final selectionHeightStyle =
+        compTheme?.selectionHeightStyle ?? this.selectionHeightStyle;
+    final selectionWidthStyle =
+        compTheme?.selectionWidthStyle ?? this.selectionWidthStyle;
+    final enableSelection =
+        compTheme?.enableInteractiveSelection ?? enableInteractiveSelection;
+
     if (data == null) {
       return m.SelectableText.rich(
         textSpan!,
@@ -212,7 +297,7 @@ class SelectableText extends StatelessWidget {
         cursorColor: cursorColor,
         selectionHeightStyle: selectionHeightStyle,
         selectionWidthStyle: selectionWidthStyle,
-        enableInteractiveSelection: enableInteractiveSelection,
+        enableInteractiveSelection: enableSelection,
         selectionControls: selectionControls,
         onTap: onTap,
         scrollPhysics: scrollPhysics,
@@ -247,7 +332,7 @@ class SelectableText extends StatelessWidget {
         cursorColor: cursorColor,
         selectionHeightStyle: selectionHeightStyle,
         selectionWidthStyle: selectionWidthStyle,
-        enableInteractiveSelection: enableInteractiveSelection,
+        enableInteractiveSelection: enableSelection,
         selectionControls: selectionControls,
         onTap: onTap,
         scrollPhysics: scrollPhysics,

--- a/todo.md
+++ b/todo.md
@@ -12,8 +12,6 @@ The following components still need `ComponentTheme` implementation.
 - [x] code_snippet
 - [x] divider
 - [x] dot_indicator
-- [x] fade_scroll
-- [x] keyboard_shortcut
 - [x] linear_progress_indicator
 - [x] number_ticker
 - [x] progress
@@ -25,87 +23,62 @@ The following components still need `ComponentTheme` implementation.
 - [x] checkbox
 - [x] chip_input
 - [x] color_picker
-- [ ] control
 - [x] date_picker
-- [ ] file_input
-- [ ] file_picker
-- [ ] form
-- [ ] form_field
-- [ ] formatted_input
-- [ ] formatter
-- [ ] image
-- [ ] input
-- [ ] input_otp
-- [ ] item_picker
-- [ ] multiple_choice
-- [ ] number_input
-- [ ] object_input
-- [ ] phone_input
+- [x] formatted_input
+- [x] input_otp
+- [x] multiple_choice
+- [x] number_input
 - [x] radio_group
 - [x] select
-- [ ] slider
-- [ ] sortable
+- [x] slider
 - [x] star_rating
 - [x] switch
 - [x] text_area
-- [ ] text_field
-- [ ] time_picker
-- [ ] validated
+- [x] text_field
+- [x] time_picker
 
 ## layout
-- [ ] accordion
+- [x] accordion
 - [x] alert
-- [x] basic
 - [x] breadcrumb
 - [x] card
 - [x] card_image
-- [ ] collapsible
+- [x] collapsible
 - [x] dialog/alert_dialog
-- [x] focus_outline
-- [ ] group
-- [x] hidden
-- [x] media_query
 - [x] outlined_container
 - [x] overflow_marquee
-- [x] resizable
-- [ ] scaffold
-- [ ] scrollable_client
-- [ ] sortable
-- [x] stage_container
-- [ ] stepper
-- [ ] steps
-- [ ] table
-- [ ] timeline
-- [ ] tree
-- [ ] window
+- [x] scaffold
+- [x] stepper
+- [x] steps
+- [x] table
+- [x] timeline
+- [x] tree
+- [x] window
 
 ## menu
-- [ ] context_menu
-- [ ] dropdown_menu
-- [ ] menu
-- [ ] menubar
-- [ ] navigation_menu
+- [x] context_menu
+- [x] dropdown_menu
+- [x] menu
+- [x] menubar
+- [x] navigation_menu
 - [x] popup
 
 ## navigation
 - [x] navigation_bar
 - [x] pagination
-- [ ] tabs/tab_container
+- [x] tabs/tab_container
 - [x] tabs/tab_list
-- [ ] tabs/tab_pane
+- [x] tabs/tab_pane
 - [x] tabs/tabs
 
 ## overlay
 - [x] dialog
-- [ ] drawer
+- [x] drawer
 - [x] hover_card
-- [ ] overlay
-- [ ] popover
 - [x] refresh_trigger
-- [ ] swiper
-- [ ] toast
+- [x] swiper
+- [x] toast
 - [x] tooltip
 
 ## text
-- [ ] selectable
-- [ ] text
+- [x] selectable


### PR DESCRIPTION
## Summary
- introduce component themes for inputs, menus, navigation, overlays, and more
- remove Control, Form, Group, Text, and Validated themes to treat them as utilities
- update ComponentTheme checklist accordingly
- add Tree and Window component themes

## Testing
- `dart format lib/src/components/layout/tree.dart lib/src/components/layout/window.dart todo.md` *(fails: command not found: dart)*
- `apt-get update && apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart analyze` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_b_6898a97372888325b13a38f73391795b