### PR TITLE
fix: Auto-focus first command item in Command palette

### DIFF
--- a/lib/src/components/control/command.dart
+++ b/lib/src/components/control/command.dart
@@ -207,7 +207,7 @@ class _CommandState extends State<Command> {
     final theme = Theme.of(context);
     bool canPop = Navigator.of(context).canPop();
     final localization = ShadcnLocalizations.of(context);
-    return SubFocusScope(builder: (context, state) {
+    return SubFocusScope(autofocus: true, builder: (context, state) {
       return Actions(
         actions: {
           NextItemIntent: CallbackAction<NextItemIntent>(


### PR DESCRIPTION
## Description

This PR enables auto-focus on the first command item when the Command palette opens or when search results update.

## Changes

- Added `autofocus: true` to `SubFocusScope` in the Command widget

## Behavior

### Before
- Users had to press arrow down to select the first command item
- Pressing Enter without navigating would do nothing

### After
- The first command item is automatically focused when the palette opens
- Users can immediately press Enter to execute the top command
- Works seamlessly when search results update

## UX Improvement

This makes the command palette behave more like popular command palettes (VS Code, Raycast, etc.) where the first item is pre-selected, improving keyboard navigation efficiency.

## Testing

Tested with:
- Opening the command dialog
- Searching and filtering results
- Pressing Enter immediately after opening
- Navigation with arrow keys still works as expected