### PR TITLE
fix: Calendar header and body alignment

### DIFF
--- a/lib/src/components/display/calendar.dart
+++ b/lib/src/components/display/calendar.dart
@@ -1832,6 +1832,7 @@ class CalendarGrid extends StatelessWidget {
     ));
     for (int i = 0; i < data.items.length; i += 7) {
       rows.add(Row(
+        mainAxisSize: MainAxisSize.min,
         children: data.items.sublist(i, i + 7).map((e) {
           return SizedBox(
             width: theme.scaling * 32,


### PR DESCRIPTION
Add a `mainAxisSize: min` property to the `Row`s used to build the `Calendar` body. This matches the size of the calendar's header row, fixing an alignment issue when the calendar is placed inside a layout widget, like a Row and Expanded.

### Before

<img width="907" height="797" alt="Screenshot 2025-10-17 at 8 43 37 AM" src="https://github.com/user-attachments/assets/6acbfcaa-3314-4003-bf89-92c213c4ab3a" />

### After

<img width="907" height="797" alt="Screenshot 2025-10-17 at 8 43 50 AM" src="https://github.com/user-attachments/assets/e8859e37-eefa-4fb7-80cd-ee98953d31d0" />
