### PR TITLE
feat: Add global enableFeedback configuration to ThemeData

### DIFF
--- a/lib/src/components/control/button.dart
+++ b/lib/src/components/control/button.dart
@@ -1106,8 +1106,13 @@ class Button extends StatefulWidget {
 
 class ButtonState<T extends Button> extends State<T> {
   bool get _shouldEnableFeedback {
-    final platform = Theme.of(context).platform;
-    return isMobile(platform);
+    final theme = Theme.of(context);
+    // Use theme setting if provided, otherwise default to platform-specific behavior
+    if (theme.enableFeedback != null) {
+      return theme.enableFeedback!;
+    }
+    // Default: enable feedback on mobile platforms
+    return isMobile(theme.platform);
   }
 
   AbstractButtonStyle? _style;

--- a/lib/src/components/navigation/navigation_bar.dart
+++ b/lib/src/components/navigation/navigation_bar.dart
@@ -1263,9 +1263,11 @@ class _NavigationItemState
 
 class NavigationButton extends AbstractNavigationButton {
   final VoidCallback? onPressed;
+  final bool enableFeedback;
   const NavigationButton({
     super.key,
     this.onPressed,
+    this.enableFeedback = true,
     super.label,
     super.spacing,
     super.style,
@@ -1324,6 +1326,7 @@ class _NavigationButtonState
         onPressed: widget.onPressed,
         marginAlignment: widget.marginAlignment,
         style: style,
+        enableFeedback: widget.enableFeedback,
         alignment: widget.alignment ??
             (data?.containerType == NavigationContainerType.sidebar &&
                     data?.labelDirection == Axis.horizontal

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -91,6 +91,7 @@ class ThemeData {
   final IconThemeProperties iconTheme;
   final double? surfaceOpacity;
   final double? surfaceBlur;
+  final bool? enableFeedback;
 
   ThemeData({
     this.colorScheme = ColorSchemes.lightDefaultColor,
@@ -101,6 +102,7 @@ class ThemeData {
     TargetPlatform? platform,
     this.surfaceOpacity,
     this.surfaceBlur,
+    this.enableFeedback,
   }) : _platform = platform;
 
   ThemeData.dark({
@@ -112,6 +114,7 @@ class ThemeData {
     TargetPlatform? platform,
     this.surfaceOpacity,
     this.surfaceBlur,
+    this.enableFeedback,
   }) : _platform = platform;
 
   /// The current platform.
@@ -160,6 +163,7 @@ class ThemeData {
     ValueGetter<IconThemeProperties>? iconTheme,
     ValueGetter<double>? surfaceOpacity,
     ValueGetter<double>? surfaceBlur,
+    ValueGetter<bool>? enableFeedback,
   }) {
     return ThemeData(
       colorScheme: colorScheme == null ? this.colorScheme : colorScheme(),
@@ -171,6 +175,8 @@ class ThemeData {
       surfaceOpacity:
           surfaceOpacity == null ? this.surfaceOpacity : surfaceOpacity(),
       surfaceBlur: surfaceBlur == null ? this.surfaceBlur : surfaceBlur(),
+      enableFeedback:
+          enableFeedback == null ? this.enableFeedback : enableFeedback(),
     );
   }
 
@@ -188,6 +194,7 @@ class ThemeData {
       iconTheme: IconThemeProperties.lerp(a.iconTheme, b.iconTheme, t),
       surfaceOpacity: lerpDouble(a.surfaceOpacity, b.surfaceOpacity, t),
       surfaceBlur: lerpDouble(a.surfaceBlur, b.surfaceBlur, t),
+      enableFeedback: t < 0.5 ? a.enableFeedback : b.enableFeedback,
     );
   }
 
@@ -202,7 +209,8 @@ class ThemeData {
         other.scaling == scaling &&
         other.iconTheme == iconTheme &&
         other.surfaceOpacity == surfaceOpacity &&
-        other.surfaceBlur == surfaceBlur;
+        other.surfaceBlur == surfaceBlur &&
+        other.enableFeedback == enableFeedback;
   }
 
   @override
@@ -215,12 +223,13 @@ class ThemeData {
       iconTheme,
       surfaceOpacity,
       surfaceBlur,
+      enableFeedback,
     );
   }
 
   @override
   String toString() {
-    return 'ThemeData(colorScheme: $colorScheme, typography: $typography, radius: $radius, scaling: $scaling, iconTheme: $iconTheme, surfaceOpacity: $surfaceOpacity, surfaceBlur: $surfaceBlur)';
+    return 'ThemeData(colorScheme: $colorScheme, typography: $typography, radius: $radius, scaling: $scaling, iconTheme: $iconTheme, surfaceOpacity: $surfaceOpacity, surfaceBlur: $surfaceBlur, enableFeedback: $enableFeedback)';
   }
 }
 


### PR DESCRIPTION
- Add enableFeedback property to ThemeData for app-wide control
- Update Button widget to respect theme setting
- Add enableFeedback parameter to NavigationButton
- Fixes audio ducking on iOS during music playback

This change allows users to globally control tap sounds/haptic feedback through the theme, which is particularly useful for music/audio apps where iOS audio ducking creates a poor UX.

The implementation is backwards compatible - when enableFeedback is null (default), the existing platform-specific behavior is preserved.