### PR TITLE
Fix scaffold crash on web due to negative viewInsets padding

### DIFF
--- a/lib/src/components/layout/scaffold.dart
+++ b/lib/src/components/layout/scaffold.dart
@@ -362,7 +362,8 @@ class ScaffoldState extends State<Scaffold> {
                         compTheme?.resizeToAvoidBottomInset ??
                         true)
                     ? Container(
-                        padding: EdgeInsets.only(bottom: viewInsets.bottom),
+                        // Clamp to prevent negative padding on web when keyboard appears
+                        padding: EdgeInsets.only(bottom: viewInsets.bottom.clamp(0.0, double.infinity)),
                         child: MediaQuery(
                           data: MediaQuery.of(context).copyWith(
                             viewInsets: viewInsets.copyWith(bottom: 0),


### PR DESCRIPTION
On web, viewInsets.bottom can become negative when the keyboard appears, causing the Container's EdgeInsets assertion to fail. This triggered Flutter's error recovery and reset navigation to home.

Added a clamp to ensure the bottom padding is never negative.

## Summary

Briefly describe what this PR changes and why.

- Motivation / Context: App scaffold rebuilds resetting the router and completely bringing the user back to the first route when the keyboard would appear in Android on Chrome on Pixel 10 Pro.
- Related discussions / background: 

## Type of change

- [X] fix: Bug fix (non-breaking change)
- [ ] feat: New feature / new component
- [ ] perf: Performance improvement
- [ ] refactor/chore: Code refactor or tooling update
- [ ] docs: Documentation only
- [ ] build/devtools: Generators, scripts, or infra changes

## Scope (check all that apply)

- [X] Components (lib/src/components/...)
- [ ] Utilities (lib/src/util.dart, animation/collection, platform)
- [ ] Icons / Fonts (icons/, lib/icons/, pubspec fonts)
- [ ] Theme / Colors (lib/src/theme/, colors/ + style transpilers)
- [ ] Docs app (docs/)
- [ ] Generators / Tools (gen/bin/)
- [ ] Example app (example/)
- [ ] Tests (example/test/, test_widget/)
- [ ] CI / Workflows

## Linked issues

Closes # Refs #

## Screenshots / Videos (if UI)

Include light/dark and relevant states.

## Breaking changes

- [ ] Yes (add migration notes below)
- [X] No

Migration notes (if breaking):

## How I tested

This was tested in our app built using ShadCN scaffold widgets. Tested on Chrome Android, Safari MacOS, Chrome MacOS, and MacOS Native.

## Checklist

Please ensure the following are complete before requesting review. See
CONTRIBUTING.md for details.

- [X] Code formatted (dart format .)
- [X] Analyzer passes (flutter analyze)
- [X] Tests added/updated and passing (flutter test where applicable)
- [X] Public API documented (public_member_api_docs)
- [X] Docs/examples updated (docs pages or README images)
- [X] Exports updated in lib/shadcn_flutter.dart (for new public widgets)
- [X] A11y validated in docs (run_docs_web_semantics.bat)
- [X] Generators run when relevant:
  - [X] LLMs / Guides (gen_dotguides.bat)
- [X] CHANGELOG updated (if user-visible change)

## Additional notes

Pretty much zero risk. Simple clamp to prevent a negative margin which solves the crash.
