### PR TITLE
[bugfix] Hide RepeatMode from flutter/widgets

### DIFF
--- a/lib/shadcn_flutter.dart
+++ b/lib/shadcn_flutter.dart
@@ -30,7 +30,8 @@ export 'package:flutter/widgets.dart'
         TableRow,
         TableCell,
         FormField,
-        RadioGroup;
+        RadioGroup,
+        RepeatMode;
 // bundle from gap
 export 'package:gap/gap.dart';
 // bundle from https://pub.dev/packages/phonecodes


### PR DESCRIPTION
## Summary

Flutter's core framework has added a `RepeatMode` enum which conflicts with Shadcn's. This PR resolves that conflict by hiding Flutter's.

## Type of change

- [x] fix: Bug fix (non-breaking change)
- [ ] feat: New feature / new component
- [ ] perf: Performance improvement
- [ ] refactor/chore: Code refactor or tooling update
- [ ] docs: Documentation only
- [ ] build/devtools: Generators, scripts, or infra changes

## Scope (check all that apply)

- [x] Components (lib/src/components/...)
- [ ] Utilities (lib/src/util.dart, animation/collection, platform)
- [ ] Icons / Fonts (icons/, lib/icons/, pubspec fonts)
- [ ] Theme / Colors (lib/src/theme/, colors/ + style transpilers)
- [ ] Docs app (docs/)
- [ ] Generators / Tools (gen/bin/)
- [ ] Example app (example/)
- [ ] Tests (example/test/, test_widget/)
- [ ] CI / Workflows

## Linked issues

Closes #378 

## Breaking changes

- [ ] Yes (add migration notes below)
- [x] No

## How I tested

- Manual verification in example app ✅ 
- Manual verification in docs app (Chrome)
- Widget tests added/updated
- Other:

## Checklist

Please ensure the following are complete before requesting review. See
CONTRIBUTING.md for details.

- [ ] Code formatted (dart format .)
- [ ] Analyzer passes (flutter analyze)
- [ ] Tests added/updated and passing (flutter test where applicable)
- [ ] Public API documented (public_member_api_docs)
- [ ] Docs/examples updated (docs pages or README images)
- [ ] Exports updated in lib/shadcn_flutter.dart (for new public widgets)
- [ ] A11y validated in docs (run_docs_web_semantics.bat)
- [ ] Generators run when relevant:
  - [ ] LLMs / Guides (gen_dotguides.bat)
- [ ] CHANGELOG updated (if user-visible change)

## Additional notes

Optional: risks, roll-out plan, or follow-ups.
