### PR TITLE
Fix RTL layout bugs in navigation rail widgets

### DIFF
--- a/lib/src/components/navigation/navigation_bar/misc.dart
+++ b/lib/src/components/navigation/navigation_bar/misc.dart
@@ -3,7 +3,7 @@ import 'package:shadcn_flutter/src/components/layout/hidden.dart';
 
 /// Returns the padding at the start of the axis.
 double startPadding(EdgeInsets padding, Axis direction) {
-  if (direction == Axis.vertical) {
+  if (direction == Axis.horizontal) {
     return padding.top;
   }
   return padding.left;
@@ -11,7 +11,7 @@ double startPadding(EdgeInsets padding, Axis direction) {
 
 /// Returns the padding at the end of the axis.
 double endPadding(EdgeInsets padding, Axis direction) {
-  if (direction == Axis.vertical) {
+  if (direction == Axis.horizontal) {
     return padding.bottom;
   }
   return padding.right;
@@ -80,11 +80,18 @@ class NavigationDivider extends StatelessWidget {
     final data = Data.maybeOf<NavigationControlData>(context);
     final parentPadding = data?.parentPadding ?? EdgeInsets.zero;
     final direction = data?.direction ?? Axis.vertical;
+    final textDir = Directionality.of(context);
     Widget child;
     if (direction == Axis.vertical) {
+      final leadingPad = textDir == TextDirection.rtl
+          ? parentPadding.right
+          : parentPadding.left;
+      final trailingPad = textDir == TextDirection.rtl
+          ? parentPadding.left
+          : parentPadding.right;
       child = Divider(
-        indent: -parentPadding.left,
-        endIndent: -parentPadding.right,
+        indent: -leadingPad,
+        endIndent: -trailingPad,
         thickness: thickness ?? (1 * scaling),
         color: color ?? theme.colorScheme.muted,
       );
@@ -184,11 +191,11 @@ class NavigationLabeled extends StatelessWidget {
             ? keepMainAxisSize
             : keepCrossAxisSize),
         child: Padding(
-          padding: EdgeInsets.only(
+          padding: EdgeInsetsDirectional.only(
             top: position == NavigationLabelPosition.bottom ? spacing : 0,
             bottom: position == NavigationLabelPosition.top ? spacing : 0,
-            left: position == NavigationLabelPosition.end ? spacing : 0,
-            right: position == NavigationLabelPosition.start ? spacing : 0,
+            start: position == NavigationLabelPosition.end ? spacing : 0,
+            end: position == NavigationLabelPosition.start ? spacing : 0,
           ),
           child: Align(
               alignment: switch (position) {


### PR DESCRIPTION
- Fix startPadding/endPadding axis condition (was Axis.vertical, should be Axis.horizontal) so the background painter covers the correct physical left/right margins for vertical rails and top/bottom for horizontal rails.
- Replace EdgeInsets.only(left/right) with EdgeInsetsDirectional.only(start/end) in NavigationLabeled so the icon-to-label spacing gap lands on the correct side (between icon and label) in RTL locales.
- Fix NavigationDivider to read Directionality.of(context) and swap parentPadding.left/right when computing indent/endIndent so horizontal dividers extend correctly into the rail's leading/trailing padding in RTL.

https://claude.ai/code/session_01EsyxeCmFL9h5v9pTE1BSK7

## Summary

Briefly describe what this PR changes and why.

- Motivation / Context:
- Related discussions / background:

## Type of change

- [x] fix: Bug fix (non-breaking change)
- [ ] feat: New feature / new component
- [ ] perf: Performance improvement
- [ ] refactor/chore: Code refactor or tooling update
- [ ] docs: Documentation only
- [ ] build/devtools: Generators, scripts, or infra changes

## Scope (check all that apply)

- [ ] Components (lib/src/components/...)
- [ ] Utilities (lib/src/util.dart, animation/collection, platform)
- [ ] Icons / Fonts (icons/, lib/icons/, pubspec fonts)
- [ ] Theme / Colors (lib/src/theme/, colors/ + style transpilers)
- [ ] Docs app (docs/)
- [ ] Generators / Tools (gen/bin/)
- [ ] Example app (example/)
- [ ] Tests (example/test/, test_widget/)
- [ ] CI / Workflows

## Linked issues

Closes # Refs #

## Screenshots / Videos (if UI)

Include light/dark and relevant states.

## Breaking changes

- [ ] Yes (add migration notes below)
- [ ] No

Migration notes (if breaking):

## How I tested

- Manual verification in example app
- Manual verification in docs app (Chrome)
- Widget tests added/updated
- Other:

## Checklist

Please ensure the following are complete before requesting review. See
CONTRIBUTING.md for details.

- [ ] Code formatted (dart format .)
- [ ] Analyzer passes (flutter analyze)
- [ ] Tests added/updated and passing (flutter test where applicable)
- [ ] Public API documented (public_member_api_docs)
- [ ] Docs/examples updated (docs pages or README images)
- [ ] Exports updated in lib/shadcn_flutter.dart (for new public widgets)
- [ ] A11y validated in docs (run_docs_web_semantics.bat)
- [ ] Generators run when relevant:
  - [ ] LLMs / Guides (gen_dotguides.bat)
- [ ] CHANGELOG updated (if user-visible change)

## Additional notes

Optional: risks, roll-out plan, or follow-ups.
