### PR TITLE
Claude/calendar rtl icons z tm eo

### DIFF
--- a/lib/src/components/display/calendar.dart
+++ b/lib/src/components/display/calendar.dart
@@ -227,7 +227,9 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Row(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
                 Expanded(
@@ -387,6 +389,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                   ),
               ],
             ),
+            ),
             Gap(theme.density.baseGap * theme.scaling * 2),
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -446,7 +449,9 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Row(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: Row(
             children: [
               OutlineButton(
                 density: ButtonDensity.icon,
@@ -521,6 +526,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                     .iconXSmall(),
               ),
             ],
+          ),
           ),
           Gap(theme.density.baseGap * theme.scaling * 2),
           buildView(

--- a/lib/src/components/display/calendar.dart
+++ b/lib/src/components/display/calendar.dart
@@ -252,7 +252,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                             }
                           });
                         },
-                        child: Icon(LucideIcons.arrowLeft, color: arrowColor)
+                        child: Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowRight : LucideIcons.arrowLeft, color: arrowColor)
                             .iconXSmall(),
                       ),
                       SizedBox(
@@ -313,7 +313,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                               }
                             });
                           },
-                          child: Icon(LucideIcons.arrowRight, color: arrowColor)
+                          child: Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowLeft : LucideIcons.arrowRight, color: arrowColor)
                               .iconXSmall(),
                         ),
                     ],
@@ -379,7 +379,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                               }
                             });
                           },
-                          child: Icon(LucideIcons.arrowRight, color: arrowColor)
+                          child: Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowLeft : LucideIcons.arrowRight, color: arrowColor)
                               .iconXSmall(),
                         ),
                       ],
@@ -466,7 +466,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                   });
                 },
                 child:
-                    Icon(LucideIcons.arrowLeft, color: arrowColor).iconXSmall(),
+                    Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowRight : LucideIcons.arrowLeft, color: arrowColor).iconXSmall(),
               ),
               SizedBox(
                 width: theme.scaling * 16,
@@ -517,7 +517,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                     }
                   });
                 },
-                child: Icon(LucideIcons.arrowRight, color: arrowColor)
+                child: Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowLeft : LucideIcons.arrowRight, color: arrowColor)
                     .iconXSmall(),
               ),
             ],

--- a/lib/src/components/display/calendar.dart
+++ b/lib/src/components/display/calendar.dart
@@ -252,7 +252,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                             }
                           });
                         },
-                        child: Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowRight : LucideIcons.arrowLeft, color: arrowColor)
+                        child: Icon(LucideIcons.arrowLeft, color: arrowColor)
                             .iconXSmall(),
                       ),
                       SizedBox(
@@ -313,7 +313,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                               }
                             });
                           },
-                          child: Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowLeft : LucideIcons.arrowRight, color: arrowColor)
+                          child: Icon(LucideIcons.arrowRight, color: arrowColor)
                               .iconXSmall(),
                         ),
                     ],
@@ -379,7 +379,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                               }
                             });
                           },
-                          child: Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowLeft : LucideIcons.arrowRight, color: arrowColor)
+                          child: Icon(LucideIcons.arrowRight, color: arrowColor)
                               .iconXSmall(),
                         ),
                       ],
@@ -466,7 +466,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                   });
                 },
                 child:
-                    Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowRight : LucideIcons.arrowLeft, color: arrowColor).iconXSmall(),
+                    Icon(LucideIcons.arrowLeft, color: arrowColor).iconXSmall(),
               ),
               SizedBox(
                 width: theme.scaling * 16,
@@ -517,7 +517,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> {
                     }
                   });
                 },
-                child: Icon(Directionality.of(context) == TextDirection.rtl ? LucideIcons.arrowLeft : LucideIcons.arrowRight, color: arrowColor)
+                child: Icon(LucideIcons.arrowRight, color: arrowColor)
                     .iconXSmall(),
               ),
             ],

--- a/lib/src/components/navigation/navigation_bar/misc.dart
+++ b/lib/src/components/navigation/navigation_bar/misc.dart
@@ -302,7 +302,7 @@ class NavigationGroup extends StatelessWidget {
       reverse: true,
       duration: kDefaultDuration,
       child: DefaultTextStyle.merge(
-        textAlign: TextAlign.start,
+        textAlign: TextAlign.center,
         maxLines: 1,
         child: NavigationChildOverflowHandle(
           overflow: labelOverflow,
@@ -364,7 +364,7 @@ class NavigationGroup extends StatelessWidget {
 
     final labelWidget = buildLabelChild(context, data);
     final paddedLabel = Container(
-      alignment: labelAlignment ?? AlignmentDirectional.centerStart,
+      alignment: labelAlignment ?? Alignment.center,
       padding: labelPadding ??
           EdgeInsets.symmetric(horizontal: densityContentPadding * padXs),
       child: labelWidget,
@@ -507,22 +507,11 @@ class _NavigationLabelDelegate extends SliverPersistentHeaderDelegate {
     final parentPadding = data?.parentPadding ?? EdgeInsets.zero;
     final direction = data?.direction ?? Axis.vertical;
     final color = theme.colorScheme.background;
-    final textDir = Directionality.of(context);
-    final resolvedIndent = direction == Axis.vertical
-        ? (textDir == TextDirection.rtl
-            ? parentPadding.right
-            : parentPadding.left)
-        : parentPadding.top;
-    final resolvedEndIndent = direction == Axis.vertical
-        ? (textDir == TextDirection.rtl
-            ? parentPadding.left
-            : parentPadding.right)
-        : parentPadding.bottom;
     return CustomPaint(
       painter: _NavigationLabelBackgroundPainter(
         color: color,
-        indent: -resolvedIndent,
-        endIndent: -resolvedEndIndent,
+        indent: -startPadding(parentPadding, direction),
+        endIndent: -endPadding(parentPadding, direction),
         direction: direction,
       ),
       child: child,

--- a/lib/src/components/navigation/navigation_bar/misc.dart
+++ b/lib/src/components/navigation/navigation_bar/misc.dart
@@ -302,7 +302,7 @@ class NavigationGroup extends StatelessWidget {
       reverse: true,
       duration: kDefaultDuration,
       child: DefaultTextStyle.merge(
-        textAlign: TextAlign.center,
+        textAlign: TextAlign.start,
         maxLines: 1,
         child: NavigationChildOverflowHandle(
           overflow: labelOverflow,
@@ -364,7 +364,7 @@ class NavigationGroup extends StatelessWidget {
 
     final labelWidget = buildLabelChild(context, data);
     final paddedLabel = Container(
-      alignment: labelAlignment ?? Alignment.center,
+      alignment: labelAlignment ?? AlignmentDirectional.centerStart,
       padding: labelPadding ??
           EdgeInsets.symmetric(horizontal: densityContentPadding * padXs),
       child: labelWidget,
@@ -507,11 +507,22 @@ class _NavigationLabelDelegate extends SliverPersistentHeaderDelegate {
     final parentPadding = data?.parentPadding ?? EdgeInsets.zero;
     final direction = data?.direction ?? Axis.vertical;
     final color = theme.colorScheme.background;
+    final textDir = Directionality.of(context);
+    final resolvedIndent = direction == Axis.vertical
+        ? (textDir == TextDirection.rtl
+            ? parentPadding.right
+            : parentPadding.left)
+        : parentPadding.top;
+    final resolvedEndIndent = direction == Axis.vertical
+        ? (textDir == TextDirection.rtl
+            ? parentPadding.left
+            : parentPadding.right)
+        : parentPadding.bottom;
     return CustomPaint(
       painter: _NavigationLabelBackgroundPainter(
         color: color,
-        indent: -startPadding(parentPadding, direction),
-        endIndent: -endPadding(parentPadding, direction),
+        indent: -resolvedIndent,
+        endIndent: -resolvedEndIndent,
         direction: direction,
       ),
       child: child,

--- a/lib/src/components/navigation/navigation_bar/misc.dart
+++ b/lib/src/components/navigation/navigation_bar/misc.dart
@@ -3,7 +3,7 @@ import 'package:shadcn_flutter/src/components/layout/hidden.dart';
 
 /// Returns the padding at the start of the axis.
 double startPadding(EdgeInsets padding, Axis direction) {
-  if (direction == Axis.vertical) {
+  if (direction == Axis.horizontal) {
     return padding.top;
   }
   return padding.left;
@@ -11,7 +11,7 @@ double startPadding(EdgeInsets padding, Axis direction) {
 
 /// Returns the padding at the end of the axis.
 double endPadding(EdgeInsets padding, Axis direction) {
-  if (direction == Axis.vertical) {
+  if (direction == Axis.horizontal) {
     return padding.bottom;
   }
   return padding.right;
@@ -80,11 +80,18 @@ class NavigationDivider extends StatelessWidget {
     final data = Data.maybeOf<NavigationControlData>(context);
     final parentPadding = data?.parentPadding ?? EdgeInsets.zero;
     final direction = data?.direction ?? Axis.vertical;
+    final textDir = Directionality.of(context);
     Widget child;
     if (direction == Axis.vertical) {
+      final leadingPad = textDir == TextDirection.rtl
+          ? parentPadding.right
+          : parentPadding.left;
+      final trailingPad = textDir == TextDirection.rtl
+          ? parentPadding.left
+          : parentPadding.right;
       child = Divider(
-        indent: -parentPadding.left,
-        endIndent: -parentPadding.right,
+        indent: -leadingPad,
+        endIndent: -trailingPad,
         thickness: thickness ?? (1 * scaling),
         color: color ?? theme.colorScheme.muted,
       );
@@ -184,11 +191,11 @@ class NavigationLabeled extends StatelessWidget {
             ? keepMainAxisSize
             : keepCrossAxisSize),
         child: Padding(
-          padding: EdgeInsets.only(
+          padding: EdgeInsetsDirectional.only(
             top: position == NavigationLabelPosition.bottom ? spacing : 0,
             bottom: position == NavigationLabelPosition.top ? spacing : 0,
-            left: position == NavigationLabelPosition.end ? spacing : 0,
-            right: position == NavigationLabelPosition.start ? spacing : 0,
+            start: position == NavigationLabelPosition.end ? spacing : 0,
+            end: position == NavigationLabelPosition.start ? spacing : 0,
           ),
           child: Align(
               alignment: switch (position) {

--- a/lib/src/components/navigation/navigation_bar/rail.dart
+++ b/lib/src/components/navigation/navigation_bar/rail.dart
@@ -222,8 +222,7 @@ class _NavigationRailState extends State<NavigationRail> {
         data: baseData,
         child: SurfaceBlur(
           surfaceBlur: widget.surfaceBlur,
-          child: AnimatedContainer(
-            duration: kDefaultDuration,
+          child: Container(
             color: widget.backgroundColor ??
                 (theme.colorScheme.background.scaleAlpha(
                   widget.surfaceOpacity ?? 1,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: shadcn_flutter
 description: "Beautifully designed components from Shadcn/UI is now available for Flutter"
 version: 0.0.52
-homepage: "https://github.com/sunarya-thito/shadcn_flutter"
+homepage: "https://github.com/f00ksh/shadcn_flutter"
 documentation: "https://sunarya-thito.github.io/shadcn_flutter/"
-repository: "https://github.com/sunarya-thito/shadcn_flutter"
-issue_tracker: "https://github.com/sunarya-thito/shadcn_flutter/issues"
+repository: "https://github.com/f00ksh/shadcn_flutter"
+issue_tracker: "https://github.com/f00ksh/shadcn_flutter/issues"
 
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
## Summary

Briefly describe what this PR changes and why.

- Motivation / Context:
- Related discussions / background:

## Type of change

- [x] fix: Bug fix (non-breaking change)
- [ ] feat: New feature / new component
- [ ] perf: Performance improvement
- [ ] refactor/chore: Code refactor or tooling update
- [ ] docs: Documentation only
- [ ] build/devtools: Generators, scripts, or infra changes

## Scope (check all that apply)

- [x] Components (lib/src/components/...)
- [ ] Utilities (lib/src/util.dart, animation/collection, platform)
- [ ] Icons / Fonts (icons/, lib/icons/, pubspec fonts)
- [ ] Theme / Colors (lib/src/theme/, colors/ + style transpilers)
- [ ] Docs app (docs/)
- [ ] Generators / Tools (gen/bin/)
- [ ] Example app (example/)
- [ ] Tests (example/test/, test_widget/)
- [ ] CI / Workflows

## Linked issues

Closes # Refs #

## Screenshots / Videos (if UI)

Include light/dark and relevant states.

## Breaking changes

- [ ] Yes (add migration notes below)
- [ ] No

Migration notes (if breaking):

## How I tested

- Manual verification in example app
- Manual verification in docs app (Chrome)
- Widget tests added/updated
- Other:

## Checklist

Please ensure the following are complete before requesting review. See
CONTRIBUTING.md for details.

- [ ] Code formatted (dart format .)
- [ ] Analyzer passes (flutter analyze)
- [ ] Tests added/updated and passing (flutter test where applicable)
- [ ] Public API documented (public_member_api_docs)
- [ ] Docs/examples updated (docs pages or README images)
- [ ] Exports updated in lib/shadcn_flutter.dart (for new public widgets)
- [ ] A11y validated in docs (run_docs_web_semantics.bat)
- [ ] Generators run when relevant:
  - [ ] LLMs / Guides (gen_dotguides.bat)
- [ ] CHANGELOG updated (if user-visible change)

## Additional notes

Optional: risks, roll-out plan, or follow-ups.
