### PR TITLE
Refactor _buildTabItem to use index instead of data

### DIFF
--- a/docs/lib/pages/docs/components/tab_pane/tab_pane_example_1.dart
+++ b/docs/lib/pages/docs/components/tab_pane/tab_pane_example_1.dart
@@ -38,7 +38,8 @@ class _TabPaneExample1State extends State<TabPaneExample1> {
   }
 
   // Render a single tab header item. It shows a badge-like count and a close button.
-  TabItem _buildTabItem(MyTab data) {
+  TabItem _buildTabItem(int index) {
+    MyTab data = tabs[index].data;
     return TabItem(
       child: ConstrainedBox(
         constraints: const BoxConstraints(minWidth: 150),
@@ -61,7 +62,7 @@ class _TabPaneExample1State extends State<TabPaneExample1> {
             icon: const Icon(Icons.close),
             onPressed: () {
               setState(() {
-                tabs.remove(data);
+                tabs.removeAt(index);
               });
             },
           ),
@@ -78,7 +79,7 @@ class _TabPaneExample1State extends State<TabPaneExample1> {
       // Provide the items and how to render each tab header.
       items: tabs,
       itemBuilder: (context, item, index) {
-        return _buildTabItem(item.data);
+        return _buildTabItem(index);
       },
       // The currently focused tab index.
       focused: focused,


### PR DESCRIPTION
https://sunarya-thito.github.io/shadcn_flutter/#/components/tab_pane cannot remove a tabpanel

## Summary

Briefly describe what this PR changes and why.

- Motivation / Context:
- Related discussions / background:

## Type of change

- [ v ] fix: Bug fix (non-breaking change)
- [ ] feat: New feature / new component
- [ ] perf: Performance improvement
- [ ] refactor/chore: Code refactor or tooling update
- [ ] docs: Documentation only
- [ ] build/devtools: Generators, scripts, or infra changes

## Scope (check all that apply)

- [ ] Components (lib/src/components/...)
- [ ] Utilities (lib/src/util.dart, animation/collection, platform)
- [ ] Icons / Fonts (icons/, lib/icons/, pubspec fonts)
- [ ] Theme / Colors (lib/src/theme/, colors/ + style transpilers)
- [ ] Docs app (docs/)
- [ ] Generators / Tools (gen/bin/)
- [ v ] Example app (example/)
- [ ] Tests (example/test/, test_widget/)
- [ ] CI / Workflows

## Linked issues

Closes # Refs #

## Screenshots / Videos (if UI)

Include light/dark and relevant states.

## Breaking changes

- [ ] Yes (add migration notes below)
- [ v ] No

Migration notes (if breaking):

## How I tested

- Manual verification in example app
- Manual verification in docs app (Chrome)
- Widget tests added/updated
- Other:

## Checklist

Please ensure the following are complete before requesting review. See
CONTRIBUTING.md for details.

- [ ] Code formatted (dart format .)
- [ ] Analyzer passes (flutter analyze)
- [ ] Tests added/updated and passing (flutter test where applicable)
- [ ] Public API documented (public_member_api_docs)
- [ ] Docs/examples updated (docs pages or README images)
- [ ] Exports updated in lib/shadcn_flutter.dart (for new public widgets)
- [ ] A11y validated in docs (run_docs_web_semantics.bat)
- [ ] Generators run when relevant:
  - [ ] LLMs / Guides (gen_dotguides.bat)
- [ ] CHANGELOG updated (if user-visible change)

## Additional notes

Optional: risks, roll-out plan, or follow-ups.
