### PR TITLE
Added a view type for the date state builder

### DIFF
--- a/lib/src/components/display/calendar.dart
+++ b/lib/src/components/display/calendar.dart
@@ -62,7 +62,7 @@ enum DateState {
 /// Takes a [DateTime] and [CalendarViewType] and returns a [DateState] to control whether
 /// that date should be enabled or disabled for user interaction.
 typedef DateStateBuilder = DateState Function(
-    DateTime date, CalendarViewType? viewType);
+    DateTime date, CalendarViewType viewType);
 
 /// Selection modes available for calendar components.
 ///
@@ -146,7 +146,7 @@ class DatePickerDialog extends StatefulWidget {
   ///   initialViewType: CalendarViewType.date,
   ///   selectionMode: CalendarSelectionMode.range,
   ///   onChanged: (value) => handleDateChange(value),
-  ///   stateBuilder: (date) => date.isBefore(DateTime.now())
+  ///   stateBuilder: (date, viewType) => date.isBefore(DateTime.now())
   ///     ? DateState.disabled
   ///     : DateState.enabled,
   /// )

--- a/lib/src/components/display/calendar.dart
+++ b/lib/src/components/display/calendar.dart
@@ -59,9 +59,9 @@ enum DateState {
 
 /// Callback function type for determining the state of calendar dates.
 ///
-/// Takes a [DateTime] and returns a [DateState] to control whether
+/// Takes a [DateTime] and [CalendarViewType] and returns a [DateState] to control whether
 /// that date should be enabled or disabled for user interaction.
-typedef DateStateBuilder = DateState Function(DateTime date);
+typedef DateStateBuilder = DateState Function(DateTime date, CalendarViewType? viewType);
 
 /// Selection modes available for calendar components.
 ///
@@ -1279,7 +1279,7 @@ class _CalendarState extends State<Calendar> {
           onTap: () {
             _handleTap(date);
           },
-          state: widget.stateBuilder?.call(date) ?? DateState.enabled,
+          state: widget.stateBuilder?.call(date, _viewType) ?? DateState.enabled,
           child: Text('${date.day}'),
         );
         if (item.fromAnotherMonth) {
@@ -1373,7 +1373,7 @@ class MonthCalendar extends StatelessWidget {
             onChanged(value.copyWith(month: () => i));
           },
           width: theme.scaling * 56,
-          state: stateBuilder?.call(date) ?? DateState.enabled,
+          state: stateBuilder?.call(date, CalendarViewType.month) ?? DateState.enabled,
           child: Text(localizations.getAbbreviatedMonth(i)),
         ),
       );

--- a/lib/src/components/display/calendar.dart
+++ b/lib/src/components/display/calendar.dart
@@ -61,7 +61,8 @@ enum DateState {
 ///
 /// Takes a [DateTime] and [CalendarViewType] and returns a [DateState] to control whether
 /// that date should be enabled or disabled for user interaction.
-typedef DateStateBuilder = DateState Function(DateTime date, CalendarViewType? viewType);
+typedef DateStateBuilder = DateState Function(
+    DateTime date, CalendarViewType? viewType);
 
 /// Selection modes available for calendar components.
 ///
@@ -1279,7 +1280,8 @@ class _CalendarState extends State<Calendar> {
           onTap: () {
             _handleTap(date);
           },
-          state: widget.stateBuilder?.call(date, _viewType) ?? DateState.enabled,
+          state: widget.stateBuilder?.call(date, CalendarViewType.date) ??
+              DateState.enabled,
           child: Text('${date.day}'),
         );
         if (item.fromAnotherMonth) {
@@ -1373,7 +1375,8 @@ class MonthCalendar extends StatelessWidget {
             onChanged(value.copyWith(month: () => i));
           },
           width: theme.scaling * 56,
-          state: stateBuilder?.call(date, CalendarViewType.month) ?? DateState.enabled,
+          state: stateBuilder?.call(date, CalendarViewType.month) ??
+              DateState.enabled,
           child: Text(localizations.getAbbreviatedMonth(i)),
         ),
       );
@@ -1471,7 +1474,8 @@ class YearCalendar extends StatelessWidget {
             onChanged(i);
           },
           width: theme.scaling * 56,
-          state: stateBuilder?.call(date) ?? DateState.enabled,
+          state: stateBuilder?.call(date, CalendarViewType.year) ??
+              DateState.enabled,
           child: Text('$i'),
         ),
       );


### PR DESCRIPTION
## Summary

Added a view type for the date state builder to allow it to be more accurate when deciding to allow the user to select the date.

- Motivation / Context:
- If you set that it's not allowed to choose before now. When displayed in Month view, you cannot choose the current month unless now is the first day of the month.

## Type of change

- [ ] fix: Bug fix (non-breaking change)
- [ ] feat: New feature / new component
- [ ] perf: Performance improvement
- [ ] refactor/chore: Code refactor or tooling update
- [ ] docs: Documentation only
- [ ] build/devtools: Generators, scripts, or infra changes

## Scope (check all that apply)

- [ ] Components (lib/src/components/...)
- [ ] Utilities (lib/src/util.dart, animation/collection, platform)
- [ ] Icons / Fonts (icons/, lib/icons/, pubspec fonts)
- [ ] Theme / Colors (lib/src/theme/, colors/ + style transpilers)
- [ ] Docs app (docs/)
- [ ] Generators / Tools (gen/bin/)
- [ ] Example app (example/)
- [ ] Tests (example/test/, test_widget/)
- [ ] CI / Workflows

## Linked issues

Closes # Refs #

## Screenshots / Videos (if UI)

Include light/dark and relevant states.

## Breaking changes

- [ ] Yes (add migration notes below)
- [ ] No

Migration notes (if breaking):

## How I tested

- Manual verification in example app
- Manual verification in docs app (Chrome)
- Widget tests added/updated
- Other:

## Checklist

Please ensure the following are complete before requesting review. See
CONTRIBUTING.md for details.

- [ ] Code formatted (dart format .)
- [ ] Analyzer passes (flutter analyze)
- [ ] Tests added/updated and passing (flutter test where applicable)
- [ ] Public API documented (public_member_api_docs)
- [ ] Docs/examples updated (docs pages or README images)
- [ ] Exports updated in lib/shadcn_flutter.dart (for new public widgets)
- [ ] A11y validated in docs (run_docs_web_semantics.bat)
- [ ] Generators run when relevant:
  - [ ] LLMs / Guides (gen_dotguides.bat)
- [ ] CHANGELOG updated (if user-visible change)

## Additional notes

Optional: risks, roll-out plan, or follow-ups.
