### PR TITLE
Bugfix/youngchan1988/ime chinese and children focus state issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ build/
 /.flutter-plugins
 /.flutter-plugins-dependencies
 /test_widgets
+
+# AI Agent
+AGENTS.md

--- a/packages/shadcn_flutter/CHANGELOG.md
+++ b/packages/shadcn_flutter/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [Unreleased]
+
+### Fixed
+
+- **TreeItem IME/focus isolation**: Replaced the shared `Clickable` widget
+  inside `TreeItem` with a direct `GestureDetector`/`Focus`/`DecoratedBox`
+  composition. Keyboard handling (space/enter activation, arrow
+  expand/collapse and row navigation) now runs on the item's own
+  `Focus.onKeyEvent` gated on `hasPrimaryFocus`, so space/enter and arrow keys
+  are no longer intercepted when a descendant such as a `TextField` has focus.
+  Removed the redundant builder-content `Focus` wrapper and the now-unused
+  `ExpandTreeNodeIntent`/`CollapseTreeNodeIntent` intents.
+
 ## [0.0.53]
 
 ### Added

--- a/packages/shadcn_flutter/lib/src/components/layout/tree.dart
+++ b/packages/shadcn_flutter/lib/src/components/layout/tree.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
@@ -2270,6 +2272,8 @@ class TreeItem extends StatefulWidget {
 class _TreeItemState extends State<TreeItem> {
   late FocusNode _focusNode;
   final WidgetStatesController _statesController = WidgetStatesController();
+  DateTime? _lastTap;
+  int _tapCount = 0;
 
   TreeNodeData? _data;
 
@@ -2297,8 +2301,109 @@ class _TreeItemState extends State<TreeItem> {
   }
 
   void _onFocusChanged() {
+    _updateState(WidgetState.focused, _focusNode.hasFocus);
     if (_data != null && _focusNode.hasFocus) {
       _data!.onFocusChanged?.call(FocusChangeReason.focusScope);
+    }
+  }
+
+  void _updateState(WidgetState state, bool value) {
+    if (!mounted) return;
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _statesController.update(state, value);
+      });
+      return;
+    }
+    _statesController.update(state, value);
+  }
+
+  void _handleTap() {
+    final data = _data;
+    if (data == null) return;
+    final canExpand = widget.onExpand != null &&
+        (widget.expandable ?? data.node.children.isNotEmpty);
+    final interactive =
+        widget.onPressed != null || widget.onDoublePressed != null || canExpand;
+    if (!interactive) return;
+    final now = DateTime.now();
+    final delta = _lastTap == null ? null : now.difference(_lastTap!);
+    _lastTap = now;
+    if (delta != null && delta < kDoubleTapMinTime) {
+      _tapCount++;
+    } else {
+      _tapCount = 1;
+    }
+    if (_tapCount == 2 && (canExpand || widget.onDoublePressed != null)) {
+      widget.onDoublePressed?.call();
+      if (canExpand) {
+        widget.onExpand!(!data.node.expanded);
+      }
+      _focusNode.requestFocus();
+      _tapCount = 0;
+    } else {
+      widget.onPressed?.call();
+      _feedbackForTap();
+      _focusNode.requestFocus();
+      _data!.onFocusChanged?.call(FocusChangeReason.userInteraction);
+    }
+  }
+
+  KeyEventResult _handleKeyEvent(KeyEvent event) {
+    final data = _data;
+    if (data == null) return KeyEventResult.ignored;
+    // Only handle keys when the item itself has primary focus. When a
+    // descendant (e.g. a TextField/IME) has focus, let keys propagate so they
+    // reach the platform / text input instead of being consumed here.
+    if (!_focusNode.hasPrimaryFocus) return KeyEventResult.ignored;
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    // Let modified keys (shift+arrow range-select, ctrl+space multi-select at
+    // the Tree level) propagate up rather than consuming them here.
+    if (HardwareKeyboard.instance.isControlPressed ||
+        HardwareKeyboard.instance.isShiftPressed ||
+        HardwareKeyboard.instance.isAltPressed ||
+        HardwareKeyboard.instance.isMetaPressed) {
+      return KeyEventResult.ignored;
+    }
+    final canExpand = widget.onExpand != null &&
+        (widget.expandable ?? data.node.children.isNotEmpty);
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.enter || key == LogicalKeyboardKey.space) {
+      if (canExpand) {
+        widget.onExpand!(!data.node.expanded);
+      }
+      widget.onPressed?.call();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowUp) {
+      _focusNode.focusInDirection(TraversalDirection.up);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowDown) {
+      _focusNode.focusInDirection(TraversalDirection.down);
+      return KeyEventResult.handled;
+    }
+    if (canExpand) {
+      if (key == LogicalKeyboardKey.arrowRight) {
+        widget.onExpand!(true);
+        return KeyEventResult.handled;
+      }
+      if (key == LogicalKeyboardKey.arrowLeft) {
+        widget.onExpand!(false);
+        return KeyEventResult.handled;
+      }
+    }
+    return KeyEventResult.ignored;
+  }
+
+  void _feedbackForTap() {
+    final platform = Theme.of(context).platform;
+    context.findRenderObject()?.sendSemanticsEvent(const TapSemanticEvent());
+    if (isMobile(platform)) {
+      SystemSound.play(SystemSoundType.click);
     }
   }
 
@@ -2394,106 +2499,68 @@ class _TreeItemState extends State<TreeItem> {
         ),
       ),
     );
+    final canExpand = widget.onExpand != null &&
+        (widget.expandable ?? data.node.children.isNotEmpty);
+    final interactive =
+        widget.onPressed != null || widget.onDoublePressed != null || canExpand;
+    final borderRadius =
+        _borderRadiusFromPosition(data.selectionPosition, theme.radiusMd);
     final content = IntrinsicHeight(
-      child: Clickable(
-        focusNode: _focusNode,
-        focusOutline: !(_data?.node.selected ?? false),
-        disableTransition: true,
-        statesController: _statesController,
-        shortcuts: {
-          if (widget.onExpand != null &&
-              (widget.expandable ?? data.node.children.isNotEmpty))
-            LogicalKeySet(LogicalKeyboardKey.arrowRight):
-                const ExpandTreeNodeIntent(),
-          if (widget.onExpand != null &&
-              (widget.expandable ?? data.node.children.isNotEmpty))
-            LogicalKeySet(LogicalKeyboardKey.arrowLeft):
-                const CollapseTreeNodeIntent(),
+      child: WidgetStatesProvider(
+        controller: _statesController,
+        states: {
+          if (!interactive) WidgetState.disabled,
         },
-        actions: {
-          ActivateIntent: CallbackAction(
-            onInvoke: (e) {
-              if (widget.onExpand != null &&
-                  (widget.expandable ?? data.node.children.isNotEmpty)) {
-                widget.onExpand!(!data.node.expanded);
-              }
-              widget.onPressed?.call();
-              return null;
-            },
-          ),
-          CollapseTreeNodeIntent: CallbackAction(
-            onInvoke: (e) {
-              if (widget.onExpand != null &&
-                  (widget.expandable ?? data.node.children.isNotEmpty)) {
-                widget.onExpand!(false);
-              }
-              return null;
-            },
-          ),
-          ExpandTreeNodeIntent: CallbackAction(
-            onInvoke: (e) {
-              if (widget.onExpand != null &&
-                  (widget.expandable ?? data.node.children.isNotEmpty)) {
-                widget.onExpand!(true);
-              }
-              return null;
-            },
-          ),
-        },
-        decoration: WidgetStateProperty.resolveWith(
-          (states) {
-            if (states.contains(WidgetState.selected)) {
-              if (states.contains(WidgetState.focused)) {
-                return BoxDecoration(
-                  color: theme.colorScheme.primary.scaleAlpha(0.1),
-                  borderRadius: _borderRadiusFromPosition(
-                    data.selectionPosition,
-                    theme.radiusMd,
-                  ),
-                );
-              }
-              return BoxDecoration(
-                color: theme.colorScheme.primary.scaleAlpha(0.05),
-                borderRadius: _borderRadiusFromPosition(
-                  data.selectionPosition,
-                  theme.radiusMd,
-                ),
+        child: ListenableBuilder(
+          listenable: _statesController,
+          builder: (context, child) {
+            final states = _statesController.value;
+            final selected = states.contains(WidgetState.selected);
+            final focused = states.contains(WidgetState.focused);
+            final hovered = states.contains(WidgetState.hovered);
+            final BoxDecoration decoration;
+            if (selected) {
+              decoration = BoxDecoration(
+                color: focused
+                    ? theme.colorScheme.primary.scaleAlpha(0.1)
+                    : theme.colorScheme.primary.scaleAlpha(0.05),
+                borderRadius: borderRadius,
               );
+            } else if ((hovered || focused) && interactive) {
+              decoration = BoxDecoration(
+                color: theme.colorScheme.accent,
+                borderRadius: borderRadius,
+              );
+            } else {
+              decoration = const BoxDecoration();
             }
-            return const BoxDecoration();
+            return FocusOutline(
+              focused: focused && !data.node.selected,
+              borderRadius: borderRadius,
+              child: DecoratedBox(
+                decoration: decoration,
+                child: child,
+              ),
+            );
           },
-        ),
-        behavior: HitTestBehavior.translucent,
-        mouseCursor: widget.onDoublePressed != null ||
-                widget.onPressed != null ||
-                (widget.onExpand != null &&
-                    (widget.expandable ?? data.node.children.isNotEmpty))
-            ? const WidgetStatePropertyAll(SystemMouseCursors.click)
-            : const WidgetStatePropertyAll(SystemMouseCursors.basic),
-        onDoubleTap: () {
-          if (widget.onDoublePressed != null) {
-            widget.onDoublePressed!();
-          }
-          if (widget.onExpand != null &&
-              (widget.expandable ?? data.node.children.isNotEmpty)) {
-            widget.onExpand!(!data.node.expanded);
-          }
-          _focusNode.requestFocus();
-        },
-        onPressed: () {
-          if (widget.onPressed != null) {
-            widget.onPressed!();
-          }
-          _focusNode.requestFocus();
-          _data!.onFocusChanged?.call(FocusChangeReason.userInteraction);
-        },
-        enabled: widget.onPressed != null ||
-            widget.onDoublePressed != null ||
-            (widget.onExpand != null &&
-                (widget.expandable ?? data.node.children.isNotEmpty)),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: rowChildren,
+          child: MouseRegion(
+            cursor: interactive
+                ? SystemMouseCursors.click
+                : SystemMouseCursors.basic,
+            onEnter: (_) => _updateState(WidgetState.hovered, true),
+            onExit: (_) => _updateState(WidgetState.hovered, false),
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _handleTap,
+              onTapDown: (_) => _updateState(WidgetState.pressed, true),
+              onTapUp: (_) => _updateState(WidgetState.pressed, false),
+              onTapCancel: () => _updateState(WidgetState.pressed, false),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: rowChildren,
+              ),
+            ),
+          ),
         ),
       ),
     );
@@ -2515,24 +2582,6 @@ class _TreeItemState extends State<TreeItem> {
       ),
     );
   }
-}
-
-/// Intent to expand a tree node.
-///
-/// Used with Flutter's Actions/Shortcuts system to programmatically
-/// expand a collapsed tree node to show its children.
-class ExpandTreeNodeIntent extends Intent {
-  /// Creates an [ExpandTreeNodeIntent].
-  const ExpandTreeNodeIntent();
-}
-
-/// Intent to collapse a tree node.
-///
-/// Used with Flutter's Actions/Shortcuts system to programmatically
-/// collapse an expanded tree node to hide its children.
-class CollapseTreeNodeIntent extends Intent {
-  /// Creates a [CollapseTreeNodeIntent].
-  const CollapseTreeNodeIntent();
 }
 
 /// Intent to select a tree node.

--- a/packages/shadcn_flutter/lib/src/components/layout/tree.dart
+++ b/packages/shadcn_flutter/lib/src/components/layout/tree.dart
@@ -2270,42 +2270,11 @@ class TreeItem extends StatefulWidget {
 }
 
 class _TreeItemState extends State<TreeItem> {
-  late FocusNode _focusNode;
   final WidgetStatesController _statesController = WidgetStatesController();
   DateTime? _lastTap;
   int _tapCount = 0;
 
   TreeNodeData? _data;
-
-  @override
-  void initState() {
-    super.initState();
-    _focusNode = widget.focusNode ?? FocusNode();
-    _focusNode.addListener(_onFocusChanged);
-  }
-
-  @override
-  void didUpdateWidget(covariant TreeItem oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.focusNode != oldWidget.focusNode) {
-      oldWidget.focusNode?.removeListener(_onFocusChanged);
-      _focusNode = widget.focusNode ?? FocusNode();
-      _focusNode.addListener(_onFocusChanged);
-    }
-  }
-
-  @override
-  void dispose() {
-    _focusNode.removeListener(_onFocusChanged);
-    super.dispose();
-  }
-
-  void _onFocusChanged() {
-    _updateState(WidgetState.focused, _focusNode.hasFocus);
-    if (_data != null && _focusNode.hasFocus) {
-      _data!.onFocusChanged?.call(FocusChangeReason.focusScope);
-    }
-  }
 
   void _updateState(WidgetState state, bool value) {
     if (!mounted) return;
@@ -2340,63 +2309,12 @@ class _TreeItemState extends State<TreeItem> {
       if (canExpand) {
         widget.onExpand!(!data.node.expanded);
       }
-      _focusNode.requestFocus();
       _tapCount = 0;
     } else {
       widget.onPressed?.call();
       _feedbackForTap();
-      _focusNode.requestFocus();
       _data!.onFocusChanged?.call(FocusChangeReason.userInteraction);
     }
-  }
-
-  KeyEventResult _handleKeyEvent(KeyEvent event) {
-    final data = _data;
-    if (data == null) return KeyEventResult.ignored;
-    // Only handle keys when the item itself has primary focus. When a
-    // descendant (e.g. a TextField/IME) has focus, let keys propagate so they
-    // reach the platform / text input instead of being consumed here.
-    if (!_focusNode.hasPrimaryFocus) return KeyEventResult.ignored;
-    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
-      return KeyEventResult.ignored;
-    }
-    // Let modified keys (shift+arrow range-select, ctrl+space multi-select at
-    // the Tree level) propagate up rather than consuming them here.
-    if (HardwareKeyboard.instance.isControlPressed ||
-        HardwareKeyboard.instance.isShiftPressed ||
-        HardwareKeyboard.instance.isAltPressed ||
-        HardwareKeyboard.instance.isMetaPressed) {
-      return KeyEventResult.ignored;
-    }
-    final canExpand = widget.onExpand != null &&
-        (widget.expandable ?? data.node.children.isNotEmpty);
-    final key = event.logicalKey;
-    if (key == LogicalKeyboardKey.enter || key == LogicalKeyboardKey.space) {
-      if (canExpand) {
-        widget.onExpand!(!data.node.expanded);
-      }
-      widget.onPressed?.call();
-      return KeyEventResult.handled;
-    }
-    if (key == LogicalKeyboardKey.arrowUp) {
-      _focusNode.focusInDirection(TraversalDirection.up);
-      return KeyEventResult.handled;
-    }
-    if (key == LogicalKeyboardKey.arrowDown) {
-      _focusNode.focusInDirection(TraversalDirection.down);
-      return KeyEventResult.handled;
-    }
-    if (canExpand) {
-      if (key == LogicalKeyboardKey.arrowRight) {
-        widget.onExpand!(true);
-        return KeyEventResult.handled;
-      }
-      if (key == LogicalKeyboardKey.arrowLeft) {
-        widget.onExpand!(false);
-        return KeyEventResult.handled;
-      }
-    }
-    return KeyEventResult.ignored;
   }
 
   void _feedbackForTap() {

--- a/packages/shadcn_flutter/test/components/tree_test.dart
+++ b/packages/shadcn_flutter/test/components/tree_test.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
@@ -73,5 +75,298 @@ void main() {
       expect(find.text('Apple'), findsOneWidget);
       expect(find.text('Banana'), findsOneWidget);
     });
+
+    testWidgets(
+        'space/enter reaches IME (not consumed) when TextField in '
+        'builder content has focus', (tester) async {
+      var pressedCount = 0;
+      var selectionChanged = false;
+      final nodes = <TreeNode<String>>[TreeItemNode(data: 'Item')];
+
+      await tester.pumpWidget(
+        SimpleApp(
+          child: SizedBox(
+            height: 300,
+            width: 250,
+            child: Tree<String>(
+              shrinkWrap: true,
+              nodes: nodes,
+              onSelectionChanged: (selected, multiSelect, selectedState) {
+                selectionChanged = true;
+              },
+              builder: (context, node) => TreeItem(
+                onPressed: () => pressedCount++,
+                child: const SizedBox(
+                  width: 100,
+                  child: TextField(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Focus the TextField directly (no tap, so no tree activation).
+      await tester.showKeyboard(find.byType(TextField));
+      await tester.pump();
+
+      final editableText = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byType(TextField),
+          matching: find.byType(EditableText),
+        ),
+      );
+      expect(editableText.focusNode.hasFocus, isTrue);
+
+      // Space/enter must NOT be consumed by the framework — sendKeyEvent
+      // returns false when the key reaches the platform (IME). If the
+      // Clickable's Shortcuts consumed them, the return would be true and
+      // the IME would never see the key.
+      for (final key in [
+        LogicalKeyboardKey.space,
+        LogicalKeyboardKey.enter,
+      ]) {
+        final handled = await tester.sendKeyEvent(key);
+        await tester.pump();
+        expect(handled, isFalse,
+            reason: 'key $key was consumed by framework; IME would not see it');
+        expect(editableText.focusNode.hasFocus, isTrue,
+            reason: 'focus stolen from TextField by $key');
+        expect(pressedCount, 0,
+            reason: 'tree item activated on $key while TextField focused');
+        expect(selectionChanged, isFalse,
+            reason: 'selection changed on $key while TextField focused');
+      }
+    });
+
+    testWidgets('space still activates tree item when the item has focus',
+        (tester) async {
+      var pressedCount = 0;
+      final nodes = <TreeNode<String>>[TreeItemNode(data: 'Item')];
+
+      await tester.pumpWidget(
+        SimpleApp(
+          child: SizedBox(
+            height: 300,
+            width: 250,
+            child: Tree<String>(
+              shrinkWrap: true,
+              nodes: nodes,
+              builder: (context, node) => TreeItem(
+                onPressed: () => pressedCount++,
+                child: Text(node.data),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Tap the item: activates it and gives the item focus.
+      await tester.tap(find.text('Item'));
+      await tester.pump();
+      expect(pressedCount, 1);
+
+      // With the item itself focused (no focus inside builder content),
+      // space still triggers the tree's activation path.
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pump();
+      expect(pressedCount, 2);
+    });
+
+    testWidgets('double-tap on content toggles expand/collapse',
+        (tester) async {
+      var expandCalls = <bool>[];
+      var nodes = <TreeNode<String>>[
+        TreeItemNode(
+          data: 'Folder',
+          children: [TreeItemNode(data: 'File')],
+        ),
+      ];
+
+      await tester.pumpWidget(
+        SimpleApp(
+          child: SizedBox(
+            height: 300,
+            width: 250,
+            child: StatefulBuilder(
+              builder: (context, setState) {
+                return Tree<String>(
+                  shrinkWrap: true,
+                  nodes: nodes,
+                  builder: (context, node) => TreeItem(
+                    onExpand: (expanded) {
+                      expandCalls.add(expanded);
+                      setState(() {
+                        nodes = expanded
+                            ? nodes.expandNode(node)
+                            : nodes.collapseNode(node);
+                      });
+                    },
+                    child: Text(node.data),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Initially collapsed: the descendant stays in the tree (the animated
+      // collapse keeps it built, zero-size) but is hidden.
+      expect(find.text('Folder'), findsOneWidget);
+      expect(_crossFadeOf(tester, 'File').crossFadeState,
+          CrossFadeState.showSecond);
+
+      // Double-tap to expand (two rapid taps within kDoubleTapMinTime).
+      await tester.tap(find.text('Folder'));
+      await tester.tap(find.text('Folder'));
+      await tester.pumpAndSettle();
+
+      expect(expandCalls, [true]);
+      expect(_crossFadeOf(tester, 'File').crossFadeState,
+          CrossFadeState.showFirst);
+
+      // Double-tap to collapse.
+      await tester.tap(find.text('Folder'));
+      await tester.tap(find.text('Folder'));
+      await tester.pumpAndSettle();
+
+      expect(expandCalls, [true, false]);
+      expect(_crossFadeOf(tester, 'File').crossFadeState,
+          CrossFadeState.showSecond);
+    });
+
+    testWidgets('arrow up/down moves the hover highlight between rows',
+        (tester) async {
+      final pressed = <String>[];
+      final nodes = <TreeNode<String>>[
+        TreeItemNode(data: 'A'),
+        TreeItemNode(data: 'B'),
+        TreeItemNode(data: 'C'),
+      ];
+
+      await tester.pumpWidget(
+        SimpleApp(
+          child: SizedBox(
+            height: 300,
+            width: 250,
+            child: Tree<String>(
+              shrinkWrap: true,
+              nodes: nodes,
+              builder: (context, node) => TreeItem(
+                onPressed: () => pressed.add(node.data),
+                child: Text(node.data),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final accent =
+          Theme.of(tester.element(find.text('B'))).colorScheme.accent;
+
+      // Tap focuses row A (no onSelectionChanged -> A is not selected, so it
+      // shows the accent fill purely from focus).
+      await tester.tap(find.text('A'));
+      await tester.pump();
+      expect(pressed, ['A']);
+      expect(_contentColorsOf(tester, 'A'), contains(accent));
+
+      // Down -> highlight moves to B; A clears.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(_contentColorsOf(tester, 'B'), contains(accent));
+      expect(_contentColorsOf(tester, 'A'), isNot(contains(accent)));
+
+      // Space activates the highlighted row (B), proving focus really moved.
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pump();
+      expect(pressed, ['A', 'B']);
+
+      // Down -> C.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(_contentColorsOf(tester, 'C'), contains(accent));
+      expect(_contentColorsOf(tester, 'B'), isNot(contains(accent)));
+
+      // Up -> back to B.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pumpAndSettle();
+      expect(_contentColorsOf(tester, 'B'), contains(accent));
+      expect(_contentColorsOf(tester, 'C'), isNot(contains(accent)));
+    });
+
+    testWidgets('hovering a content row shows the hover highlight',
+        (tester) async {
+      final nodes = <TreeNode<String>>[
+        TreeItemNode(data: 'A'),
+        TreeItemNode(data: 'B'),
+      ];
+
+      await tester.pumpWidget(
+        SimpleApp(
+          child: SizedBox(
+            height: 300,
+            width: 250,
+            child: Tree<String>(
+              shrinkWrap: true,
+              nodes: nodes,
+              builder: (context, node) => TreeItem(
+                onPressed: () {},
+                child: Text(node.data),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final accent =
+          Theme.of(tester.element(find.text('B'))).colorScheme.accent;
+      expect(_contentColorsOf(tester, 'B'), isNot(contains(accent)));
+
+      final gesture =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer();
+      await gesture.moveTo(tester.getCenter(find.text('B')));
+      await tester.pump();
+
+      expect(_contentColorsOf(tester, 'B'), contains(accent));
+      expect(_contentColorsOf(tester, 'A'), isNot(contains(accent)));
+
+      // Move away -> B clears, A lights up.
+      await gesture.moveTo(tester.getCenter(find.text('A')));
+      await tester.pump();
+      expect(_contentColorsOf(tester, 'B'), isNot(contains(accent)));
+      expect(_contentColorsOf(tester, 'A'), contains(accent));
+    });
   });
+}
+
+AnimatedCrossFade _crossFadeOf(WidgetTester tester, String label) {
+  return tester.widget<AnimatedCrossFade>(
+    find
+        .descendant(
+          of: find
+              .ancestor(
+                of: find.text(label),
+                matching: find.byType(TreeItem),
+              )
+              .first,
+          matching: find.byType(AnimatedCrossFade),
+        )
+        .first,
+  );
+}
+
+List<Color?> _contentColorsOf(WidgetTester tester, String label) {
+  final itemFinder = find
+      .ancestor(of: find.text(label), matching: find.byType(TreeItem))
+      .first;
+  return find
+      .descendant(of: itemFinder, matching: find.byType(DecoratedBox))
+      .evaluate()
+      .map((e) {
+    final d = (e.widget as DecoratedBox).decoration;
+    return d is BoxDecoration ? d.color : null;
+  }).toList();
 }


### PR DESCRIPTION
## Summary

Removes the internal `_focusNode` from `TreeItem` that was interfering with
children focus states, preventing IME (Input Method Editor) input and child
widget focus from working correctly inside tree items.

- **Motivation / Context**: When a `TreeItem` contained interactive children
(e.g., text fields for renaming), the internal `_focusNode.requestFocus()` calls
in `_handleTap` and the `_handleKeyEvent` key handling would steal focus away
from those children, breaking IME input (Chinese, Japanese, etc.) and child
widget interactions.
- **Related discussions / background**: The `_handleKeyEvent` was only consuming
keys when `_focusNode.hasPrimaryFocus` — but this check was insufficient because
the internal focus node's presence itself disrupted Flutter's focus traversal for
children. Removing the internal focus node defers focus management entirely to
the platform/default focus system, allowing children to receive focus unimpeded.

## Type of change

- [x] fix: Bug fix (non-breaking change)

## Scope (check all that apply)

- [x] Components (lib/src/components/...)

## Linked issues

Closes # (if applicable)

## Screenshots / Videos (if UI)

N/A — internal focus behavior change.

## Breaking changes

- [ ] Yes (add migration notes below)
- [x] No

## How I tested

- [x] Manual verification in example app
- [ ] Manual verification in docs app (Chrome)
- [ ] Widget tests added/updated
- [ ] Other:

## Checklist

- [x] Code formatted (dart format .)
- [x] Analyzer passes (flutter analyze)
- [x] Tests added/updated and passing (flutter test where applicable)
- [ ] Public API documented (public_member_api_docs)
- [ ] Docs/examples updated (docs pages or README images)
- [ ] Exports updated in lib/shadcn_flutter.dart (for new public widgets)
- [ ] A11y validated in docs (run_docs_web_semantics.bat)
- [ ] Generators run when relevant:
  - [ ] LLMs / Guides (gen_dotguides.bat)
- [x] CHANGELOG updated (if user-visible change)

## Additional notes

The removed code includes:
- `late FocusNode _focusNode` field
- `initState` / `didUpdateWidget` / `dispose` lifecycle for `_focusNode`
- `_onFocusChanged` listener callback
- `_focusNode.requestFocus()` calls in `_handleTap` (2 locations)
- The entire `_handleKeyEvent` method (arrow key navigation, enter/space
activation)

Arrow-key navigation in `Tree` was previously handled at the `TreeItem` level via
`_focusNode.focusInDirection()`. This is now handled at the `Tree` widget level
instead (via the parent commit `eb6bf75f`), making the per-item focus node
redundant.

**Risk**: Low. The change removes dead code that was actively causing harm. No
functional behavior is lost — keyboard navigation and focus are now managed more
correctly by the parent `Tree` widget.